### PR TITLE
feat(agents): hardened artifact guard prevents fabricated work

### DIFF
--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -14,6 +14,7 @@
 const { createClient } = require('@supabase/supabase-js');
 const { Redis } = require('@upstash/redis');
 const express = require('express');
+const { validateArtifactQuality } = require('./artifactGuard');
 
 // ============================================
 // THE CONSTITUTION - IMMUTABLE PRINCIPLES
@@ -499,6 +500,12 @@ CRITERIA: ${task.success_criteria}
             return await this.recordConfused(task, 'artifact_missing', { output: result.output.substring(0, 500) });
         }
 
+        // ARTIFACT_GUARD_HARDENED: stronger content-quality check (independent of ESCALATION_CONTRACT)
+        const guard = await this._runArtifactGuardCheck(task);
+        if (!guard.skipped && !guard.verdict.valid) {
+            return await this.handleArtifactRejection(task, guard.artifact, guard.verdict.reason);
+        }
+
         const evaluation = await this.evaluateResult(result.output, task);
         
         if (evaluation.score < 40) {
@@ -558,6 +565,59 @@ CRITERIA: ${task.success_criteria}
             claimed_by: null,
             result: `[RELEASED] ${reason}`
         }).eq('id', taskId);
+    }
+
+    // --- ARTIFACT GUARD HARDENING (gated by ARTIFACT_GUARD_HARDENED env flag) ---
+
+    async _runArtifactGuardCheck(task) {
+        if (process.env.ARTIFACT_GUARD_HARDENED !== 'true') {
+            return { skipped: true };
+        }
+        let artifact = null;
+        if (this.lastArtifactId) {
+            try {
+                const { data } = await this.supabase
+                    .from('trinity_artifacts')
+                    .select('id, content')
+                    .eq('id', this.lastArtifactId)
+                    .maybeSingle();
+                artifact = data || null;
+            } catch (e) {
+                console.warn(`[GUARD] Read failed for artifact ${this.lastArtifactId}: ${e.message}`);
+            }
+        }
+        const verdict = validateArtifactQuality(artifact, task);
+        return { skipped: false, artifact, verdict };
+    }
+
+    async handleArtifactRejection(task, artifact, reason) {
+        const detail = `artifact_guard_rejection:${reason}`;
+        const artifactRef = artifact && artifact.id != null ? artifact.id : 'none';
+        console.warn(`[GUARD] 🛑 ${this.name} rejected task ${task.id}: ${reason} (artifact ${artifactRef})`);
+        try {
+            await this.supabase.from('trinity_tasks').update({
+                status: 'failed',
+                result: `[GUARD_REJECTED] ${reason}`
+            }).eq('id', task.id);
+        } catch (e) {
+            console.error(`[GUARD] Task update failed: ${e.message}`);
+        }
+        try {
+            await this.insertEscalationLog(task.id, detail);
+        } catch (e) {
+            console.error(`[GUARD] escalation_log insert failed: ${e.message}`);
+        }
+        try {
+            await this.insertHitlRequest(
+                task.id,
+                'guard_rejected',
+                `${detail}; artifact_id=${artifactRef}`,
+                { artifact_id: artifact && artifact.id != null ? artifact.id : null, rejection_reason: reason }
+            );
+        } catch (e) {
+            console.error(`[GUARD] hitl insert failed: ${e.message}`);
+        }
+        this.currentTaskId = null;
     }
 
     async getVerificationTask() {
@@ -787,6 +847,12 @@ VIRTUE: ${this.wisdom.primaryVirtue}
 
                 this.currentTaskId = null;
                 return;
+            }
+
+            // ARTIFACT_GUARD_HARDENED: stronger content-quality check (legacy path)
+            const guard = await this._runArtifactGuardCheck(task);
+            if (!guard.skipped && !guard.verdict.valid) {
+                return await this.handleArtifactRejection(task, guard.artifact, guard.verdict.reason);
             }
 
             await this.supabase.from('trinity_tasks').update({

--- a/lib/artifactGuard.js
+++ b/lib/artifactGuard.js
@@ -1,0 +1,44 @@
+/**
+ * ARTIFACT GUARD — content-quality validation for trinity_artifacts.
+ *
+ * Pure helper: no DB, no I/O. Given a saved artifact row and the task it
+ * belongs to, returns { valid: true } or { valid: false, reason }.
+ *
+ * Reason codes (stable; logged into escalation_log):
+ *   empty_content   — content is null/undefined/whitespace-only
+ *   echo_identical  — content trims to exactly task.description (rows 95602/95603)
+ *   too_short       — content < 100 chars after trim
+ *   echo_overlap    — content shares a >=50-char prefix or suffix with task.description
+ */
+
+const SHORT_CONTENT_FLOOR = 100;
+const OVERLAP_THRESHOLD = 50;
+
+function validateArtifactQuality(artifact, task) {
+    if (!artifact || artifact.content == null || String(artifact.content).trim() === '') {
+        return { valid: false, reason: 'empty_content' };
+    }
+
+    const trimmedContent = String(artifact.content).trim();
+    const trimmedDesc = (task && typeof task.description === 'string') ? task.description.trim() : '';
+
+    if (trimmedDesc.length > 0 && trimmedContent === trimmedDesc) {
+        return { valid: false, reason: 'echo_identical' };
+    }
+
+    if (trimmedContent.length < SHORT_CONTENT_FLOOR) {
+        return { valid: false, reason: 'too_short' };
+    }
+
+    if (trimmedDesc.length >= OVERLAP_THRESHOLD) {
+        const prefix = trimmedDesc.slice(0, OVERLAP_THRESHOLD);
+        const suffix = trimmedDesc.slice(-OVERLAP_THRESHOLD);
+        if (trimmedContent.startsWith(prefix) || trimmedContent.endsWith(suffix)) {
+            return { valid: false, reason: 'echo_overlap' };
+        }
+    }
+
+    return { valid: true };
+}
+
+module.exports = { validateArtifactQuality, SHORT_CONTENT_FLOOR, OVERLAP_THRESHOLD };

--- a/scripts/verify-artifact-guard.js
+++ b/scripts/verify-artifact-guard.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Standalone verification for lib/artifactGuard.js.
+ * No jest in this repo, so this script doubles as the unit-test harness.
+ *
+ * Run: node scripts/verify-artifact-guard.js
+ * Exit code: 0 if all scenarios pass, 1 otherwise.
+ */
+
+const { validateArtifactQuality } = require('../lib/artifactGuard');
+
+const scenarios = [
+    {
+        name: 'valid: distinct prose well over 100 chars',
+        artifact: { id: 1, content: 'The query was executed against trinity_kv_store and returned 3 receipt-indexer cursor keys, all advanced within the last 30 minutes. No staleness detected. Indexer is healthy.' },
+        task: { id: 1, description: 'Query trinity_kv_store for keys starting with "receipt_indexer_cursor:". For each, verify lastBlock has advanced compared to the previous reading.' },
+        expectValid: true,
+        expectReason: undefined,
+    },
+    {
+        name: 'reject: empty string content',
+        artifact: { id: 2, content: '' },
+        task: { id: 2, description: 'Some task description that is long enough to exceed the overlap threshold of fifty characters of text.' },
+        expectValid: false,
+        expectReason: 'empty_content',
+    },
+    {
+        name: 'reject: whitespace-only content',
+        artifact: { id: 3, content: '   \n\t  ' },
+        task: { id: 3, description: 'Some task description that is long enough to exceed the overlap threshold of fifty characters of text.' },
+        expectValid: false,
+        expectReason: 'empty_content',
+    },
+    {
+        name: 'reject: null artifact',
+        artifact: null,
+        task: { id: 4, description: 'Some task description that is long enough to exceed the overlap threshold of fifty characters of text.' },
+        expectValid: false,
+        expectReason: 'empty_content',
+    },
+    {
+        name: 'reject: row 95602-style verbatim echo',
+        artifact: { id: 95602, content: 'Count trinity_hitl_requests rows where status=pending in the last 1 hour. After escalation contract activation (ESCALATION_CONTRACT=true on trinity-veritas), this should occasionally be > 0. If 0 for the whole window, that may indicate the contract is not firing.' },
+        task: { id: 200443, description: 'Count trinity_hitl_requests rows where status=pending in the last 1 hour. After escalation contract activation (ESCALATION_CONTRACT=true on trinity-veritas), this should occasionally be > 0. If 0 for the whole window, that may indicate the contract is not firing.' },
+        expectValid: false,
+        expectReason: 'echo_identical',
+    },
+    {
+        name: 'reject: echo with only whitespace differences',
+        artifact: { id: 6, content: '\n  Count repid_score_events grouped by (delta sign, agent_id) for the last 4 hours. Flag any agent receiving only positive OR only negative deltas (concentration risk).  \n' },
+        task: { id: 6, description: 'Count repid_score_events grouped by (delta sign, agent_id) for the last 4 hours. Flag any agent receiving only positive OR only negative deltas (concentration risk).' },
+        expectValid: false,
+        expectReason: 'echo_identical',
+    },
+    {
+        name: 'reject: content under 100 chars',
+        artifact: { id: 7, content: 'Done.' },
+        task: { id: 7, description: 'Some unrelated task description that is long enough to exceed the overlap threshold of fifty characters of text.' },
+        expectValid: false,
+        expectReason: 'too_short',
+    },
+    {
+        name: 'reject: content starts with first 50 chars of description',
+        artifact: { id: 8, content: 'Count trinity_hitl_requests rows where status=pending and then I went on to write a bunch of additional prose claiming I did the work, padded out to comfortably exceed the 100-char floor.' },
+        task: { id: 8, description: 'Count trinity_hitl_requests rows where status=pending in the last 1 hour. After escalation contract activation, etc.' },
+        expectValid: false,
+        expectReason: 'echo_overlap',
+    },
+    {
+        name: 'reject: content ends with last 50 chars of description',
+        artifact: { id: 9, content: 'Some lengthy preamble that pads out the front so the prefix check does not fire, followed verbatim by the trailing portion: positive OR only negative deltas (concentration risk).' },
+        task: { id: 9, description: 'Count repid_score_events grouped by (delta sign, agent_id) for the last 4 hours. Flag any agent receiving only positive OR only negative deltas (concentration risk).' },
+        expectValid: false,
+        expectReason: 'echo_overlap',
+    },
+    {
+        name: 'valid: short description (below overlap threshold) + distinct content',
+        artifact: { id: 10, content: 'I executed the requested action and the result is documented here in over one hundred characters of prose so the floor check does not trigger.' },
+        task: { id: 10, description: 'Do a thing.' },
+        expectValid: true,
+        expectReason: undefined,
+    },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const s of scenarios) {
+    const got = validateArtifactQuality(s.artifact, s.task);
+    const okValid = got.valid === s.expectValid;
+    const okReason = s.expectValid ? true : got.reason === s.expectReason;
+    if (okValid && okReason) {
+        console.log(`PASS  ${s.name}`);
+        passed++;
+    } else {
+        console.log(`FAIL  ${s.name}`);
+        console.log(`      expected: valid=${s.expectValid} reason=${s.expectReason ?? '(n/a)'}`);
+        console.log(`      got:      valid=${got.valid} reason=${got.reason ?? '(n/a)'}`);
+        failed++;
+    }
+}
+
+console.log('');
+console.log(`Total: ${scenarios.length}  Passed: ${passed}  Failed: ${failed}`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Adds content-quality validation that rejects artifacts that are empty, byte-identical to the task description, trivially short (<100 chars), or trivial prefix/suffix echoes of the description.

Production agents have been writing artifacts with content equal to task.description (rows 95602, 95603) or LLM-generated prose that fabricates results without doing real work (rows 95600, 95601). The existing artifact-existence guard (in d185de57) only checked that an artifact row existed; it did not validate content quality.

This change adds:
  - lib/artifactGuard.js: pure validateArtifactQuality helper
  - Call sites in BOTH legacy processTask and processTaskContract, gated behind new ARTIFACT_GUARD_HARDENED env flag
  - handleArtifactRejection: marks task failed, logs to escalation_log, creates HITL request (reuses existing insertEscalationLog and insertHitlRequest helpers)
  - scripts/verify-artifact-guard.js: 10-scenario verification runner (no jest installed in this repo)

Flag is independent of ESCALATION_CONTRACT. Either flag can be on or off, in any combination. Default behavior (no flag set) is identical to current production.

Refs: FABRICATED_ARTIFACTS_TRIAGE report 2026-05-09

## What does this change?

## Why?

## How was it tested?

## Affected ecosystem repos
- [ ] hyperdag-protocol
- [ ] hyperdag-core
- [ ] trinity-symphony-shared
- [ ] repid
- [ ] trustrepid

## Checks
- [ ] I confirm I have not modified protected core paths (if any)