### PR TITLE
feat(spawner): evergreen recurrence via runLoop idle branch (Phase 4 A1)

### DIFF
--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -398,6 +398,127 @@ class ConstitutionalAgentV4 {
         }
     }
 
+    /**
+     * Sprint MVP-Delivery Phase 4 (A1) — Evergreen Spawner.
+     *
+     * Fires from the runLoop idle branch on every iteration that finds no work.
+     * Polls trinity_tasks for is_evergreen=true rows where recurring_minutes
+     * has elapsed since last_spawned_at (or NULL last_spawned_at = never spawned).
+     * Atomic optimistic-concurrency guard on the parent update prevents two
+     * agents from double-spawning the same parent.
+     *
+     * γ policy on recurring_minutes: skip NULL (Strategy Claude ruling for Sean
+     * triage). A separate manifest of NULL-recurring evergreens lives in
+     * E:\dev\reports\2026-05-20\CC_PHASE_4_REPORT.md.
+     *
+     * Bugfixes vs the un-deployed lib/ConstitutionalAgent.ts scaffold:
+     *  1. Uses is_evergreen=true (was title-match '[EVERGREEN]')
+     *  2. Sets last_spawned_at on parent (was missing)
+     *  3. Sets parent_task_id on child (was missing)
+     *  4. Increments spawned_count on parent (was missing)
+     *  5. Honors recurring_minutes cadence (was ignored)
+     *  6. Not gated on verified-status only (cadence-driven, status-agnostic)
+     */
+    async respawnEvergreensIfDue() {
+        try {
+            const { data: due, error: selErr } = await this.supabase
+                .from('trinity_tasks')
+                .select('id, title, description, task_type, assigned_to, priority, success_criteria, max_duration_minutes, last_spawned_at, spawned_count, recurring_minutes, metadata')
+                .eq('is_evergreen', true)
+                .not('recurring_minutes', 'is', null)
+                .or(`last_spawned_at.is.null,last_spawned_at.lt.${new Date(Date.now() - 60_000).toISOString()}`)
+                .order('last_spawned_at', { ascending: true, nullsFirst: true })
+                .limit(5);
+
+            if (selErr) {
+                console.error(`[EVERGREEN] select error:`, selErr.message, selErr);
+                return { processed: 0 };
+            }
+            if (!due || due.length === 0) return { processed: 0 };
+
+            let processed = 0;
+            const nowIso = new Date().toISOString();
+
+            for (const parent of due) {
+                const minutesSince = parent.last_spawned_at
+                    ? (Date.now() - new Date(parent.last_spawned_at).getTime()) / 60_000
+                    : Infinity;
+                if (minutesSince < parent.recurring_minutes) continue;
+
+                // Atomic guard: claim the cadence slot.
+                // Predicate matches the captured last_spawned_at OR NULL → other agents lose the race.
+                let claimQuery = this.supabase
+                    .from('trinity_tasks')
+                    .update({
+                        last_spawned_at: nowIso,
+                        spawned_count: (parent.spawned_count || 0) + 1
+                    })
+                    .eq('id', parent.id)
+                    .eq('is_evergreen', true);
+                if (parent.last_spawned_at === null) {
+                    claimQuery = claimQuery.is('last_spawned_at', null);
+                } else {
+                    claimQuery = claimQuery.eq('last_spawned_at', parent.last_spawned_at);
+                }
+                const { data: claimed, error: claimErr } = await claimQuery.select('id').maybeSingle();
+
+                if (claimErr) {
+                    console.error(`[EVERGREEN] cadence-slot claim error parent=${parent.id}:`, claimErr.message, claimErr);
+                    continue;
+                }
+                if (!claimed) {
+                    // Lost the race to another agent. Not an error.
+                    continue;
+                }
+
+                // Insert the child spawn. is_evergreen=false; parent_task_id set.
+                const childTitle = parent.title || `[EVERGREEN spawn ${parent.id}]`;
+                const childDescription = parent.description || `Evergreen recurrence of task ${parent.id}`;
+                const childMeta = Object.assign({}, parent.metadata || {}, {
+                    spawned_from_evergreen: parent.id,
+                    spawned_at: nowIso,
+                    spawner_agent: this.name,
+                    spawner_phase: 'CC_MVP_DELIVERY_PHASE_4_A1'
+                });
+
+                const childRow = {
+                    title: childTitle,
+                    description: childDescription,
+                    task_type: parent.task_type,
+                    assigned_to: parent.assigned_to,
+                    priority: parent.priority || 5,
+                    status: 'pending',
+                    is_evergreen: false,
+                    parent_task_id: parent.id,
+                    success_criteria: parent.success_criteria,
+                    max_duration_minutes: parent.max_duration_minutes,
+                    metadata: childMeta
+                };
+
+                const { data: child, error: insErr } = await this.supabase
+                    .from('trinity_tasks')
+                    .insert(childRow)
+                    .select('id')
+                    .single();
+
+                if (insErr) {
+                    console.error(`[EVERGREEN] child insert failed parent=${parent.id}:`, insErr.message, insErr);
+                    // Parent's last_spawned_at is already advanced — this cadence is consumed.
+                    // Next cadence interval will retry. Acceptable trade-off vs UPDATE-after-INSERT
+                    // which permits double-INSERT under contention.
+                    continue;
+                }
+                processed += 1;
+                console.log(`[EVERGREEN] ♻️ spawned child ${child?.id} from parent ${parent.id} (cadence=${parent.recurring_minutes}min, spawned_count=${(parent.spawned_count || 0) + 1})`);
+            }
+
+            return { processed };
+        } catch (e) {
+            console.error(`[EVERGREEN] respawnEvergreensIfDue exception:`, e?.message, e?.stack);
+            return { processed: 0 };
+        }
+    }
+
     async runLoop() {
         if (!this.isEscalationContractEnabled) {
             return this.runLoopLegacy();
@@ -431,6 +552,13 @@ class ConstitutionalAgentV4 {
                     }
                     if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.checkGroupHealth(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'checkGroupHealth(idle)');
                     if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.runStaleTaskReaper(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'runStaleTaskReaper(idle)');
+                    // Sprint MVP-Delivery Phase 4 (A1) — evergreen spawner on idle.
+                    // Lower priority than service-contract poll (above) and survivor checks.
+                    try {
+                        await withTimeout(this.respawnEvergreensIfDue(), LOOP_TIMEOUTS.DB_QUERY, 'respawnEvergreensIfDue(idle-contract)');
+                    } catch (e) {
+                        console.error(`[${this.name}] respawnEvergreensIfDue error:`, e?.message, e?.stack);
+                    }
                     await this.sleep(30000);
                     continue;
                 }
@@ -501,6 +629,13 @@ class ConstitutionalAgentV4 {
                 }
                 if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.checkGroupHealth(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'checkGroupHealth');
                 if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.runStaleTaskReaper(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'runStaleTaskReaper');
+                // Sprint MVP-Delivery Phase 4 (A1) — evergreen spawner on each loop iteration.
+                // Legacy path runs even when a task is processed (cheap; cadence-gated server-side).
+                try {
+                    await withTimeout(this.respawnEvergreensIfDue(), LOOP_TIMEOUTS.DB_QUERY, 'respawnEvergreensIfDue(legacy)');
+                } catch (e) {
+                    console.error(`[${this.name}] respawnEvergreensIfDue error:`, e?.message, e?.stack);
+                }
                 await this.sleep(30000);
             } catch (err) {
                 this.sessionMetrics.tasksFailed++; // Sprint 14 R-3 — count failed iterations


### PR DESCRIPTION
Closes the spawner "designed but unwired" gap surfaced by Phase 1 diagnosis: lib/ConstitutionalAgent.ts (.ts scaffold, NOT deployed) had a respawnEvergreen function with 5+ bugs; the deployed runtime lib/ConstitutionalAgentV4.js had no evergreen logic at all. Zero of 68 evergreens have ever produced a child task (verified Phase 1).

New method respawnEvergreensIfDue() on ConstitutionalAgentV4, called from BOTH runLoop() (escalation-contract idle branch) and runLoopLegacy() (every iteration). Wrapped in withTimeout via LOOP_TIMEOUTS.DB_QUERY (10s) per the R-1 safety net pattern. Catches log loudly (RULE-11), never throw to the loop.

Selects:
  is_evergreen=true
  AND recurring_minutes IS NOT NULL    (Strategy Claude γ policy — skip-NULL)
  AND (last_spawned_at IS NULL OR last_spawned_at < NOW() - 60s)

Cadence gate confirmed client-side against parent.recurring_minutes. Atomic optimistic-concurrency on parent UPDATE (predicate matches the captured last_spawned_at OR NULL) — lost race → skip, not an error.

Bugfixes vs the un-deployed scaffold:
  1. is_evergreen=true filter (was '[EVERGREEN]' title-match — would miss 41 of 71 rows including CAIT and system-task evergreens)
  2. Sets parent.last_spawned_at on each spawn (was missing)
  3. Sets child.parent_task_id link (was missing)
  4. Increments parent.spawned_count (was missing)
  5. Honors parent.recurring_minutes cadence (was ignored)
  6. Status-agnostic on parent (was over-gated on verified-only)

NULL-recurring evergreens (32 of 68) deliberately skipped per γ; manifest for Sean triage in CC_PHASE_4_REPORT.md.

CC Sprint MVP-Delivery Phase 4 (A1).

## What does this change?

## Why?

## How was it tested?

## Affected ecosystem repos
- [x] hyperdag-protocol
- [ ] hyperdag-core
- [x] trinity-symphony-shared
- [x] repid
- [ ] trustrepid

## Checks
- [ ] I confirm I have not modified protected core paths (if any)