### PR TITLE
fix(heartbeat): bounded upserts + circuit breaker + non-gating runLoo…

### DIFF
--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -160,7 +160,23 @@ class ConstitutionalAgentV4 {
         // [ANTIGRAVITY] Task Claim Blacklist - prevent infinite retries on problematic tasks
         this.claimHistory = new Map();
         this.MAX_CLAIM_RETRIES = 3;
+
+        // Phase 7C (Unbounded Wait Disease — heartbeat resilience) — circuit
+        // breaker against sustained-degraded Supabase. heartbeat() runs every
+        // 120s via setInterval AND inline within runLoop. Without bounded
+        // upserts, a slow upstream pinned each call until network completed,
+        // piling up in-flight requests + delaying the runLoop. With this
+        // breaker: after HEARTBEAT_CIRCUIT_OPEN_THRESHOLD consecutive failures,
+        // future heartbeat() calls short-circuit return until the cool-down
+        // window passes. Counter resets on first full success.
+        // Per CLAUDE-RULE-8 NEVER UNBOUNDED WAIT.
+        this.consecutiveHeartbeatFailures = 0;
+        this.heartbeatCircuitOpenUntil = 0;          // ms timestamp; 0 = closed
+        this.heartbeatCircuitOpenLogged = false;
     }
+
+    get HEARTBEAT_CIRCUIT_OPEN_THRESHOLD() { return 5; }
+    get HEARTBEAT_CIRCUIT_OPEN_SLEEP_MS() { return 5 * 60 * 1000; }
 
     detectProviders() {
         return Object.keys(PROVIDERS).filter(k => process.env[PROVIDERS[k].envKey]).sort((a, b) => PROVIDERS[a].priority - PROVIDERS[b].priority);
@@ -222,23 +238,32 @@ class ConstitutionalAgentV4 {
     }
 
     async heartbeat(statusMessage = 'Idle') {
+        // Phase 7C — circuit-open early-return. Skip the call entirely if
+        // we're in the cool-down window from a recent failure burst. Logged
+        // once at the open boundary (heartbeatCircuitOpenLogged gate).
+        if (this.heartbeatCircuitOpenUntil > Date.now()) {
+            return;
+        }
+
         const timestamp = new Date().toISOString();
         try {
             // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
-            await this.supabase.from('trinity_agent_registry').upsert({
+            // Phase 7C — withTimeout(10s) wrap so a degraded Supabase can't
+            // pin the heartbeat call indefinitely. Per CLAUDE-RULE-8.
+            await withTimeout(this.supabase.from('trinity_agent_registry').upsert({
                 agent_name: this.name,
                 status: 'online', // SSOT ALIGNMENT: UI expects 'online' or 'active' for Green
                 last_active: timestamp,
                 current_tier: this.wisdom.tier || 'specialist',
                 tasks_completed: this.sessionMetrics.tasksCompleted,
                 current_task_summary: this.currentTaskId ? `Working on task ${this.currentTaskId}` : statusMessage
-            }, { onConflict: 'agent_name' });
+            }, { onConflict: 'agent_name' }), LOOP_TIMEOUTS.DB_QUERY, 'heartbeat:trinity_agent_registry');
 
             // Sprint 14 R-3 — publish the previously-dead instrumentation
             // columns so the data layer can distinguish loop-alive from
             // heartbeat-alive. loop_count is owned by the runLoop (incremented
             // inside the loop body); this writer only publishes it.
-            await this.supabase.from('agent_heartbeat').upsert({
+            await withTimeout(this.supabase.from('agent_heartbeat').upsert({
                 agent_name: this.name,
                 status: 'online',
                 last_ping: timestamp,
@@ -248,10 +273,10 @@ class ConstitutionalAgentV4 {
                 tasks_failed_session: this.sessionMetrics.tasksFailed,
                 code_version: this.version,
                 railway_service_id: process.env.RAILWAY_SERVICE_ID || null
-            }, { onConflict: 'agent_name' });
+            }, { onConflict: 'agent_name' }), LOOP_TIMEOUTS.DB_QUERY, 'heartbeat:agent_heartbeat');
 
             // [ANTIGRAVITY] Sync with trinity_heartbeat for audit-heartbeats compatibility
-            await this.supabase.from('trinity_heartbeat').upsert({
+            await withTimeout(this.supabase.from('trinity_heartbeat').upsert({
                 agent: this.name,
                 status: 'online',
                 last_seen: timestamp,
@@ -261,9 +286,26 @@ class ConstitutionalAgentV4 {
                     group: this.wisdom.squad || 'ORCHESTRATION',
                     tier: this.wisdom.tier || 'specialist'
                 }
-            }, { onConflict: 'agent' });
+            }, { onConflict: 'agent' }), LOOP_TIMEOUTS.DB_QUERY, 'heartbeat:trinity_heartbeat');
+
+            // Phase 7C — full success → reset breaker state.
+            if (this.consecutiveHeartbeatFailures > 0 || this.heartbeatCircuitOpenLogged) {
+                console.log(`[${this.name}] [heartbeat] circuit-breaker reset after ${this.consecutiveHeartbeatFailures} consecutive failures`);
+                this.consecutiveHeartbeatFailures = 0;
+                this.heartbeatCircuitOpenLogged = false;
+                this.heartbeatCircuitOpenUntil = 0;
+            }
         } catch (e) {
-            console.error('Heartbeat failed', e.message);
+            // Phase 7C — bounded-failure path. Increment counter; open the
+            // circuit once threshold crosses. heartbeat() is observability,
+            // not gating (Sean spec) — NEVER re-throws.
+            this.consecutiveHeartbeatFailures += 1;
+            console.error(`[${this.name}] Heartbeat failed (consecutive=${this.consecutiveHeartbeatFailures}/${this.HEARTBEAT_CIRCUIT_OPEN_THRESHOLD}):`, e.message);
+            if (this.consecutiveHeartbeatFailures >= this.HEARTBEAT_CIRCUIT_OPEN_THRESHOLD && !this.heartbeatCircuitOpenLogged) {
+                this.heartbeatCircuitOpenLogged = true;
+                this.heartbeatCircuitOpenUntil = Date.now() + this.HEARTBEAT_CIRCUIT_OPEN_SLEEP_MS;
+                console.error(`[${this.name}] [heartbeat] CIRCUIT OPEN — ${this.HEARTBEAT_CIRCUIT_OPEN_THRESHOLD}+ consecutive failures; suppressing heartbeat() for ${this.HEARTBEAT_CIRCUIT_OPEN_SLEEP_MS}ms (5min) until cool-down`);
+            }
         }
     }
 
@@ -564,7 +606,14 @@ class ConstitutionalAgentV4 {
                 }
 
                 console.log(`[${this.name}] 📋 Processing (Contract): ${task.title}`);
-                await withTimeout(this.heartbeat(`Claimed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Claimed task=${task.id})`);
+                // Phase 7C — heartbeat is observability, not gating. Wrap
+                // in inline try/catch so a degraded Supabase doesn't insert
+                // a 30s stall into the task-claim path (per Sean spec).
+                try {
+                    await withTimeout(this.heartbeat(`Claimed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Claimed task=${task.id})`);
+                } catch (e) {
+                    console.warn(`[${this.name}] heartbeat non-fatal in runLoop(claimed): ${e?.message ?? e}`);
+                }
 
                 // STEP 1: Atomic Claim
                 const claimed = await withTimeout(this.claimTask(task.id), LOOP_TIMEOUTS.DB_QUERY, `claimTask(${task.id})`);
@@ -623,9 +672,20 @@ class ConstitutionalAgentV4 {
                 const task = await withTimeout(this.getNextTask(), LOOP_TIMEOUTS.DB_QUERY, 'getNextTask');
                 if (task) {
                     console.log(`[${this.name}] 📋 Processing: ${task.title}`);
-                    await withTimeout(this.heartbeat(`Claimed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Claimed task=${task.id})`);
+                    // Phase 7C — heartbeat is observability, not gating
+                    // (per Sean spec). Inline try/catch so a degraded
+                    // Supabase doesn't stall the legacy work path.
+                    try {
+                        await withTimeout(this.heartbeat(`Claimed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Claimed task=${task.id})`);
+                    } catch (e) {
+                        console.warn(`[${this.name}] heartbeat non-fatal in runLoopLegacy(claimed): ${e?.message ?? e}`);
+                    }
                     await withTimeout(this.processTask(task), LOOP_TIMEOUTS.LLM_OR_INTERNAL, `processTask(id=${task.id})`);
-                    await withTimeout(this.heartbeat(`Completed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Completed task=${task.id})`);
+                    try {
+                        await withTimeout(this.heartbeat(`Completed: ${task.title}`), LOOP_TIMEOUTS.DB_QUERY, `heartbeat(Completed task=${task.id})`);
+                    } catch (e) {
+                        console.warn(`[${this.name}] heartbeat non-fatal in runLoopLegacy(completed): ${e?.message ?? e}`);
+                    }
                 }
                 if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.checkGroupHealth(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'checkGroupHealth');
                 if (this.isSurvivor && Math.random() < 0.1) await withTimeout(this.runStaleTaskReaper(), LOOP_TIMEOUTS.SURVIVOR_HELPER, 'runStaleTaskReaper');


### PR DESCRIPTION
…p wraps (Phase 7C)

Closes the swarm-wide freeze mechanism that recurred 2026-05-21: when Supabase compute degraded (planning times 3-82s), the agent's heartbeat() upserts hung indefinitely. The 2-min setInterval kept firing fresh heartbeats which piled up in-flight. runLoop's withTimeout-wrapped heartbeat calls eventually triggered TimeoutError, which propagated to the runLoop's outer catch and forced a 30s sleep on every iteration — effectively gating work on heartbeat health. All 12 trinity agents went heartbeat-stale ~18:06-18:55 UTC and stayed frozen for 110-160 min.

This is "Unbounded Wait Disease" applied to the agent heartbeat path, mirror of Phase 7B's proof-drain fix. Per CLAUDE-RULE-8 NEVER UNBOUNDED WAIT.

Three additive defenses:

  1. EACH SUPABASE UPSERT INSIDE heartbeat() WRAPPED with withTimeout + LOOP_TIMEOUTS.DB_QUERY (existing 10s constant — confirmed exists, no new constant added per Sean spec): - trinity_agent_registry upsert - agent_heartbeat upsert (Sprint 14 R-3 9-column write) - trinity_heartbeat upsert (audit-compat) Each labeled distinctly ('heartbeat:trinity_agent_registry' etc.) so timeout errors are identifiable in logs.

  2. CIRCUIT BREAKER at heartbeat() entry. Instance fields: this.consecutiveHeartbeatFailures (counter, 0 at boot)
       this.heartbeatCircuitOpenUntil    (ms timestamp; 0 = closed)
       this.heartbeatCircuitOpenLogged   (one-shot log gate)
     Threshold 5 consecutive failures → 5-min cool-down window.
     During the window, heartbeat() returns early without attempting
     any upsert. Reset to 0 on first full success. The existing
     setInterval(120000) continues to fire but each fire short-
     circuits during the cool-down — no pile-up.

  3. RUNLOOP HEARTBEAT CALL SITES NOW NON-GATING (per Sean spec "heartbeat failures should NEVER hang the runLoop"). Three call sites in runLoop / runLoopLegacy wrapped in inline try/catch:
       - runLoop (escalation contract) at "Processing (Contract):" - runLoopLegacy at "Processing: claimed" - runLoopLegacy at "Processing: completed" A heartbeat timeout now logs `[${name}] heartbeat non-fatal in runLoop*: ${msg}` and continues to next operation. Previously a timeout propagated to runLoop's outer catch → 30s sleep per iteration → effectively gated all work on heartbeat health.

start() initial heartbeat at line 192 left un-wrapped: heartbeat() is now self-bounded internally (max ~30s if all three upserts time out), boot-time call returns within that ceiling regardless. setInterval at line 194 is fire-and-forget so timing doesn't pile up there either.

Patent gate: clean. No comma math literals, no PCP internals, no RepID formula.

RULE-3 strict scope: only the heartbeat resilience seams. No refactors to runLoop body, runLoopLegacy body, processTask, claimTask, getNextTask, checkGroupHealth, runStaleTaskReaper, etc. Those wraps stay as-is.

Verified locally: node --check lib/ConstitutionalAgentV4.js (exit 0).

CC Sprint MVP-Delivery Phase 7C (heartbeat resilience).

## What does this change?

## Why?

## How was it tested?

## Affected ecosystem repos
- [ ] hyperdag-protocol
- [ ] hyperdag-core
- [ ] trinity-symphony-shared
- [ ] repid
- [ ] trustrepid

## Checks
- [ ] I confirm I have not modified protected core paths (if any)