### PR TITLE
docs(readme): align Ecosystem Governance with canonical roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ which can demote underperforming LLM providers or re-route tasks to higher-reput
 
 ## 🏗️ Ecosystem Governance
 
+The **protocol-wide** governance roadmap (RepID formula, Pythagorean Comma damping, peer-verification thresholds, the V1 → V3 path toward a DAO) is canonical at
+[**hyperdag-protocol / GOVERNANCE_ROADMAP.md**](https://github.com/DealAppSeo/hyperdag-protocol/blob/main/GOVERNANCE_ROADMAP.md).
+
+This repo (`trinity-symphony-shared`) governs the **swarm-local** surface that runs on top of the protocol:
+
+- **Agent constitutions** — what an individual agent will and will not do
+- **Swarm policies** — BFT quorum thresholds, ALPHA Truth Squad rules, squad-role escalation paths
+- **Ethics logic** — the kernel that adjudicates agent decisions before they propagate
+
 | Repository | Role | Technology Stack |
 | :--- | :--- | :--- |
 | **[hyperdag-protocol](https://github.com/DealAppSeo/hyperdag-protocol)** | Truth | Solidity, Circom, Merkle DAG |


### PR DESCRIPTION
## Why

Sean's governance roadmap is now canonical in `hyperdag-protocol/GOVERNANCE_ROADMAP.md` (merged `0cfeb9c`). This README's `Ecosystem Governance` section should:

1. NOT duplicate the full roadmap (avoid drift)
2. Point at the canonical doc
3. Briefly document what `trinity-symphony-shared` *specifically* governs vs. what's protocol-wide

## What

Additive edit only — no existing content removed:

- **Added** a 2-sentence preamble pointing at the canonical `GOVERNANCE_ROADMAP.md` as the protocol-wide source of truth.
- **Added** a 3-bullet list naming this repo's swarm-local governance surface (agent constitutions / swarm policies / ethics logic) — using vocabulary already present in this repo's own `CONSTITUTION.md` (BFT quorum, ALPHA Truth Squad, squad-role escalation).
- **Kept** the existing Truth/Soul repo-mapping table unchanged.
- **Kept** the existing `[Constitution] • [Contributing] • [Security]` link line.

No other section touched.

## Diff scope

`+9 lines, -0 lines` (purely additive).