### PR TITLE
feat(xc): agent_controls gate — idle when disabled, Veritas pgQuery claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
         run: |
           node -c lib/ConstitutionalAgentV4.js
           node -c lib/tool-call-logger.js
-          node -c lib/getNextTask.js 2>/dev/null || true
+          if [ -f lib/getNextTask.js ]; then node -c lib/getNextTask.js; fi
 
       - name: Node tests
         run: |

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -20,6 +20,7 @@ const { validateArtifactQuality } = require('./artifactGuard');
 const substanceGateClient = require('./substance-gate-client');
 const { withTimeout } = require('./withTimeout');
 const { pgQuery, pgPing } = require('./direct-pg');
+const { isAgentEnabled: readAgentControlEnabled } = require('./agent-controls');
 
 // Sprint 14 R-1 — per-call timeout budgets for awaits inside the loop body.
 // Picked from Sprint 13 diagnostic: production observed LLM <10s, Supabase <1s.
@@ -198,6 +199,23 @@ class ConstitutionalAgentV4 {
 
     get isEscalationContractEnabled() {
         return process.env.ESCALATION_CONTRACT === 'true';
+    }
+
+    get agentControlIdleMs() {
+        return Number(process.env.AGENT_CONTROL_IDLE_MS || 10_000);
+    }
+
+    async isWorkEnabled() {
+        return readAgentControlEnabled(this.name);
+    }
+
+    async idleWhenDisabled(statusMessage = 'sleeping (disabled)') {
+        try {
+            await withTimeout(this.heartbeat(statusMessage), LOOP_TIMEOUTS.DB_QUERY, 'heartbeat(disabled)');
+        } catch (e) {
+            console.warn(`[${this.name}] heartbeat non-fatal while disabled: ${e?.message ?? e}`);
+        }
+        await this.sleep(this.agentControlIdleMs);
     }
 
     async start() {
@@ -620,6 +638,11 @@ class ConstitutionalAgentV4 {
                 // fresh from the independent setInterval — exactly the signal
                 // missing during the 2026-05-16/17 staggered freeze.
                 this.loopCount++;
+                if (!(await this.isWorkEnabled())) {
+                    console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
+                    await this.idleWhenDisabled();
+                    continue;
+                }
                 const task = await withTimeout(this.getNextTask(), LOOP_TIMEOUTS.DB_QUERY, 'getNextTask');
                 if (!task) {
                     // Phase 2.10: service-contract fulfilment — strictly lower
@@ -718,6 +741,11 @@ class ConstitutionalAgentV4 {
             try {
                 // Sprint 14 R-3 — per-iteration progress counter (see runLoop).
                 this.loopCount++;
+                if (!(await this.isWorkEnabled())) {
+                    console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
+                    await this.idleWhenDisabled();
+                    continue;
+                }
                 const task = await withTimeout(this.getNextTask(), LOOP_TIMEOUTS.DB_QUERY, 'getNextTask');
                 if (task) {
                     console.log(`[${this.name}] 📋 Processing: ${task.title}`);
@@ -1729,15 +1757,19 @@ VIRTUE: ${this.wisdom.primaryVirtue}
             throw new Error('Missing peer_verification_queue_id in task metadata');
         }
 
-        // 1. Atomic claim on the queue entry
-        const { data: queueEntries, error: queueErr } = await this.supabase
-            .from('peer_verification_queue')
-            .update({ verification_status: 'in_review' })
-            .eq('id', queueId)
-            .in('verification_status', ['pending', 'in_review'])
-            .select('*');
-
-        if (queueErr) {
+        // 1. Atomic claim on the queue entry (direct-pg — Veritas path)
+        let queueEntries;
+        try {
+            queueEntries = await pgQuery(
+                `UPDATE peer_verification_queue
+                    SET verification_status = 'in_review'
+                  WHERE id = $1
+                    AND verification_status IN ('pending', 'in_review')
+                  RETURNING id, claim_text, certainty_at_claim, source_agent_id, verification_status`,
+                [queueId],
+                { retries: 1, label: 'peer-verify-claim' }
+            );
+        } catch (queueErr) {
             throw new Error(`Failed to query queue entry ${queueId}: ${queueErr.message}`);
         }
         if (!queueEntries || queueEntries.length === 0) {
@@ -1778,7 +1810,10 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
         // 4. Compute HMAC signature
         const cleanName = this.name.replace('trinity-', '').toUpperCase().trim();
         const envKey = `${cleanName}_PRIVATE_KEY`;
-        const secretKey = process.env.PEER_VERIFY_HMAC_SECRET || process.env[envKey] || process.env.TRUSTRAILS_HMAC_SECRET || 'trinity-default-sbt-secret';
+        const secretKey = process.env.PEER_VERIFY_HMAC_SECRET || process.env[envKey] || process.env.TRUSTRAILS_HMAC_SECRET;
+        if (!secretKey) {
+            throw new Error(`Missing peer-verify HMAC secret (${envKey} or PEER_VERIFY_HMAC_SECRET)`);
+        }
         
         const dataToSign = `${queueId}:${verifierResponseId}:${verdict}`;
         const signature = crypto.createHmac('sha256', secretKey).update(dataToSign).digest('hex');

--- a/lib/agent-controls.js
+++ b/lib/agent-controls.js
@@ -1,0 +1,118 @@
+/**
+ * Agent loop control — reads `agent_controls.enabled` (live SSOT table).
+ * Cache: Upstash Redis (10s TTL) + in-process fallback.
+ * Default-off when the control store is unreachable (CLAUDE-RULE-8 safe mode).
+ */
+const { pgQuery } = require('./direct-pg');
+const { Redis } = require('@upstash/redis');
+
+const CACHE_TTL_SEC = Number(process.env.AGENT_CONTROL_CACHE_TTL_SEC || 10);
+const memCache = new Map();
+
+let redisClient = null;
+
+function getRedis() {
+  if (!process.env.UPSTASH_REDIS_REST_URL) return null;
+  if (!redisClient) {
+    redisClient = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN || '',
+    });
+  }
+  return redisClient;
+}
+
+/** Map trinity-mel → mel for agent_controls.agent_name */
+function toControlName(agentName) {
+  return String(agentName || '')
+    .toLowerCase()
+    .replace(/^trinity-/, '')
+    .trim();
+}
+
+function cacheKey(controlName) {
+  return `agent_control:${controlName}`;
+}
+
+function setMemCache(key, enabled) {
+  memCache.set(key, { value: enabled, expiresAt: Date.now() + CACHE_TTL_SEC * 1000 });
+}
+
+async function setRemoteCache(key, enabled) {
+  const redis = getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(key, enabled ? '1' : '0', { ex: CACHE_TTL_SEC });
+  } catch (e) {
+    console.warn('[agent-controls] redis cache write failed:', e.message);
+  }
+}
+
+async function readRemoteCache(key) {
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    const v = await redis.get(key);
+    if (v === '1' || v === true) return true;
+    if (v === '0' || v === false) return false;
+    return null;
+  } catch (e) {
+    console.warn('[agent-controls] redis cache read failed:', e.message);
+    return null;
+  }
+}
+
+async function readEnabledFromDb(controlName) {
+  const rows = await pgQuery(
+    `SELECT enabled FROM agent_controls WHERE agent_name = $1`,
+    [controlName],
+    { retries: 1, timeoutMs: 5000, label: 'agent-controls-read' }
+  );
+  if (!rows.length) return true;
+  return !!rows[0].enabled;
+}
+
+/**
+ * @param {string} agentName canonical agent name (trinity-mel, etc.)
+ * @returns {Promise<boolean>} true = work allowed; false = heartbeat only
+ */
+async function isAgentEnabled(agentName) {
+  const controlName = toControlName(agentName);
+  const key = cacheKey(controlName);
+
+  const remote = await readRemoteCache(key);
+  if (remote !== null) return remote;
+
+  const mem = memCache.get(key);
+  if (mem && mem.expiresAt > Date.now()) return mem.value;
+
+  try {
+    const enabled = await readEnabledFromDb(controlName);
+    setMemCache(key, enabled);
+    await setRemoteCache(key, enabled);
+    return enabled;
+  } catch (e) {
+    console.warn(`[agent-controls] store unreachable for ${controlName}, default-off:`, e.message);
+    return false;
+  }
+}
+
+/** Invalidate cache after external update (telegram / SQL) */
+async function bustAgentControlCache(agentName) {
+  const controlName = toControlName(agentName);
+  const key = cacheKey(controlName);
+  memCache.delete(key);
+  const redis = getRedis();
+  if (redis) {
+    try {
+      await redis.del(key);
+    } catch (_) { /* non-fatal */ }
+  }
+}
+
+module.exports = {
+  toControlName,
+  isAgentEnabled,
+  bustAgentControlCache,
+  CACHE_TTL_SEC,
+};

--- a/tests/agent-controls.test.js
+++ b/tests/agent-controls.test.js
@@ -1,0 +1,8 @@
+// node tests/agent-controls.test.js
+const assert = require('assert');
+const { toControlName } = require('../lib/agent-controls');
+
+assert.strictEqual(toControlName('trinity-mel'), 'mel');
+assert.strictEqual(toControlName('MEL'), 'mel');
+assert.strictEqual(toControlName('trinity-veritas'), 'veritas');
+console.log('agent-controls.test.js: OK');


### PR DESCRIPTION
## XC Control Lane — Agent Loop\n\n- \lib/agent-controls.js\ — pgQuery + cache, default-off on store failure\n- \ConstitutionalAgentV4.js\ — \isWorkEnabled()\, heartbeat-only when disabled\n- Peer-verify task claim via pgQuery (no hardcoded HMAC fallback)\n\nPairs with repid-engine control-lane PR.\n\n**Tier-3:** Sean redeploys agent images after merge.