### PR TITLE
fix(egress): single-row atomic claim — kill the SELECT* poll (P0, 6/22 cliff)

### DIFF
--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -1468,32 +1468,49 @@ CRITERIA: ${task.success_criteria}
     }
 
     async getNextTask() {
-        // PostgREST bypass (2026-05-21) — direct pg SELECT in place of the
-        // supabase query builder. Same predicates: agent-or-unassigned, open
-        // statuses, unclaimed, priority DESC then oldest-first. No LIMIT — the
-        // blacklist filter below needs the full candidate set. retries:1 (the
-        // runLoop call sites still wrap getNextTask() in withTimeout). RULE-8.
-        // S-QUORUM Phase 5 — capability-based claiming filter (gated CAPABILITY_FILTER, default OFF).
-        // Agents shadow_reject task types they have no handler for (cait/EVERGREEN ≈ 84% of rejects,
-        // per S-HARDEN), wasting claim/release cycles. When enabled, the query only returns task
-        // types this agent can handle; a NULL task_type is always allowed. Default off => capFilter
-        // is null => the predicate is a no-op (byte-identical to prior behavior).
+        // EGRESS FIX (2026-06-19, CC; spec CC-egress-claim-rewrite-spec.md v2, Grok red-team GO)
+        // RECONCILED with S-QUORUM Phase 5 (#25, a0863fdf) on rebase 2026-06-19.
+        // The old `SELECT * ... ORDER BY ... (no LIMIT)` returned the WHOLE candidate set every poll
+        // (666–1098 wide rows) — ~880 GB/day egress, the #1 driver of the Supabase breach. Replaced
+        // with a SINGLE-ROW ATOMIC CLAIM: select ONE claimable row, exclude the in-memory blacklist
+        // IN-SQL, FOR UPDATE SKIP LOCKED (race-safe, distinct row per agent), claim it to 'doing' in
+        // the same statement, narrow RETURNING (no SELECT *). LIMIT 1 fixes egress regardless of
+        // predicate width (the bug was unbounded row COUNT, not predicate). The claim now happens
+        // HERE; claimTask() below is an idempotent ownership-confirm so existing call sites keep
+        // working unchanged.
+        // PRESERVED from #25: (a) the assigned_to/agent_assigned candidate predicate, (b) the open
+        // status set incl. 'assigned', (c) the gated CAPABILITY_FILTER (default OFF => $5 NULL =>
+        // task_type predicate is a no-op). trinity_tasks.id is BIGINT (CLAUDE-RULE-5) => blacklist
+        // cast ::bigint[], NOT ::uuid[].
         const CAPABILITY_FILTER = process.env.CAPABILITY_FILTER === 'true';
         const HANDLED = (process.env.AGENT_TASK_TYPES ||
             'peer_verify,review,meta,system,research,code,docs,artifact,critique')
             .split(',').map(s => s.trim()).filter(Boolean);
         const capFilter = CAPABILITY_FILTER ? HANDLED : null;
-        let tasks;
+        const now = new Date().toISOString();
+        const blacklist = [];
+        for (const [id, n] of this.claimHistory) {
+            if (n >= this.MAX_CLAIM_RETRIES) blacklist.push(id);
+        }
+        let rows;
         try {
-            tasks = await pgQuery(
-                `SELECT * FROM trinity_tasks
-                 WHERE (assigned_to = $1 OR (assigned_to IS NULL AND (agent_assigned = $1 OR agent_assigned IS NULL)))
-                   AND status = ANY($2)
-                   AND claimed_by IS NULL
-                   AND ($3::text[] IS NULL OR task_type IS NULL OR task_type = ANY($3))
-                 ORDER BY priority DESC, created_at ASC`,
-                [this.name, ['pending', 'todo', 'assigned', 'pending_clarification'], capFilter],
-                { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'getNextTask' }
+            rows = await pgQuery(
+                `UPDATE trinity_tasks
+                    SET status = 'doing', claimed_by = $1, claimed_at = $2, started_at = $2
+                  WHERE id = (
+                    SELECT id FROM trinity_tasks
+                     WHERE (assigned_to = $1 OR (assigned_to IS NULL AND (agent_assigned = $1 OR agent_assigned IS NULL)))
+                       AND status = ANY($3)
+                       AND claimed_by IS NULL
+                       AND ($5::text[] IS NULL OR task_type IS NULL OR task_type = ANY($5))
+                       AND NOT (id = ANY($4::bigint[]))
+                     ORDER BY priority DESC, created_at ASC
+                     LIMIT 1
+                     FOR UPDATE SKIP LOCKED
+                  )
+                  RETURNING id, title, description, metadata, priority, task_type, agent_assigned, status`,
+                [this.name, now, ['pending', 'todo', 'assigned', 'pending_clarification'], blacklist, capFilter],
+                { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'getNextTask(atomic-claim)' }
             );
         } catch (error) {
             console.error(`[${this.name}] ❌ getNextTask query error:`, {
@@ -1503,39 +1520,27 @@ CRITERIA: ${task.success_criteria}
             return null;
         }
 
-        if (!tasks || tasks.length === 0) return null;
-
-        // Filter out blacklisted tasks
-        for (const t of tasks) {
-            const retries = this.claimHistory.get(t.id) || 0;
-            if (retries < this.MAX_CLAIM_RETRIES) {
-                return t;
-            }
-            console.log(`[${this.name}] 🚫 Skipping blacklisted task ${t.id} (${retries} failed attempts)`);
-        }
-        return null;
+        if (!rows || rows.length === 0) return null;
+        return rows[0]; // already atomically claimed by THIS agent ('doing', claimed_by = this.name)
     }
 
     async claimTask(taskId) {
+        // EGRESS FIX (2026-06-19): the atomic claim now happens inside getNextTask() (single-row
+        // UPDATE...RETURNING). This is now an idempotent OWNERSHIP-CONFIRM so the existing call sites
+        // (runLoop STEP 1 + processTask) keep working unchanged: returns true iff THIS agent already
+        // owns the task ('doing', claimed_by = this.name). Cheap single-row lookup; no SELECT *, no
+        // re-claim race. RULE-8.
         try {
-            // PostgREST bypass (2026-05-21) — atomic optimistic claim via direct
-            // pg UPDATE..RETURNING (replaces the supabase update+select). The
-            // WHERE guard (status open AND claimed_by IS NULL) keeps the claim
-            // race-safe: only one agent's UPDATE matches, so RETURNING is
-            // non-empty for exactly the winner. retries:1 — never re-issue a
-            // claim. RULE-8 (10s ceiling).
-            const now = new Date().toISOString();
             const rows = await pgQuery(
-                `UPDATE trinity_tasks
-                 SET status = 'doing', claimed_by = $1, claimed_at = $2, started_at = $2
-                 WHERE id = $3 AND status = ANY($4) AND claimed_by IS NULL
-                 RETURNING id`,
-                [this.name, now, taskId, ['pending', 'todo', 'pending_clarification']],
-                { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'claimTask' }
+                `SELECT 1 FROM trinity_tasks
+                  WHERE id = $1 AND claimed_by = $2 AND status = 'doing'
+                  LIMIT 1`,
+                [taskId, this.name],
+                { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'claimTask(confirm)' }
             );
             return rows.length > 0;
         } catch (e) {
-            console.error(`[${this.name}] ❌ Claim error:`, {
+            console.error(`[${this.name}] ❌ Claim confirm error:`, {
                 message: e.message,
                 code: e.code || null,
                 details: e.details || null


### PR DESCRIPTION
**P0 egress fix.** Replaces the no-LIMIT `SELECT *` poll in `getNextTask()` (666-1098 wide rows/poll = ~880GB/day, the Supabase breach driver) with a single-row atomic claim (FOR UPDATE SKIP LOCKED, blacklist in-SQL, `status='doing'`, `::bigint[]`). claimTask() -> idempotent ownership-confirm; call sites unchanged.

Grok red-team: **GO**. GA blind: **Option A**. Verified: node --check OK; EXPLAIN on prod valid (LIMIT 1 plan).

**Deploy target:** the 12 Trinity agent services (AITrinitySymphony). **Acceptance after deploy:** pg_stat_statements rows/call on the poll drops ~666 -> ~1; egress meter flattens.
Follow-up (optional, Tier-2): partial index `(agent_assigned, priority DESC, created_at) WHERE claimed_by IS NULL`.

🤖 Drafted by CC (Claude Code).