### PR TITLE
perf(agent): throttle presence writes — HEARTBEAT_MODE (full|throttled|off) + richer /health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,4 @@ jobs:
           node tests/getNextTask.test.js
           node tests/provenance.test.js
           node tests/pulseCheckExecutor.test.js
+          node tests/heartbeatDbWritesGate.test.js

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -116,6 +116,22 @@ function canonicalizeProvider(providerKey) {
     return clean;
 }
 
+/**
+ * Resolve the tri-state presence-write mode from the new HEARTBEAT_MODE env and
+ * the legacy HEARTBEAT_DB_WRITES flag. Precedence:
+ *   1. Explicit HEARTBEAT_MODE = full|throttled|off  → wins.
+ *   2. Otherwise map legacy HEARTBEAT_DB_WRITES: 'off' → 'off', anything else → 'full'.
+ *   3. Neither set → 'full' (preserves today's exact default behavior).
+ * Any unrecognized HEARTBEAT_MODE value falls through to the legacy mapping.
+ */
+function resolveHeartbeatMode(modeEnv, legacyEnv) {
+    const mode = (modeEnv || '').toLowerCase().trim();
+    if (mode === 'full' || mode === 'throttled' || mode === 'off') return mode;
+    // Legacy fallback: HEARTBEAT_DB_WRITES=off → off; default (on/unset) → full.
+    const legacy = (legacyEnv || 'on').toLowerCase().trim();
+    return legacy === 'off' ? 'off' : 'full';
+}
+
 class ConstitutionalAgentV4 {
     constructor(config = {}) {
         // PATENT-PENDING: MULTIPLICATIVE_GNN_O(LOG_N) TRUST_SCALING
@@ -181,13 +197,38 @@ class ConstitutionalAgentV4 {
         // version label locally. Surfaced in /health only — no DB write.
         this.codeVersion = process.env.RAILWAY_GIT_COMMIT_SHA || this.version;
 
-        // HEARTBEAT_DB_WRITES gate (2026-07). DEFAULT 'on' = preserve today's
-        // behavior exactly (per-iteration agent_heartbeat + trinity_agent_registry
-        // presence upserts). Set to 'off' to delegate liveness to UptimeRobot's
-        // /health checks + in-memory loop state and stop the ~8.6M/day meaningless
-        // presence writes. Durable write-on-CHANGE for genuinely-persistent
-        // registry config fields is NOT gated by this flag (see persistRegistryConfig).
-        this.heartbeatDbWrites = (process.env.HEARTBEAT_DB_WRITES || 'on').toLowerCase() !== 'off';
+        // HEARTBEAT_MODE tri-state gate (2026-07). Controls ONLY the per-iteration
+        // presence upserts (trinity_agent_registry presence + agent_heartbeat +
+        // trinity_heartbeat). Durable write-on-CHANGE for genuinely-persistent
+        // registry config fields is NEVER gated by this (see persistRegistryConfig).
+        //
+        //   'full'      — DEFAULT. Preserve today's exact behavior: all 3 presence
+        //                 upserts fire on EVERY heartbeat() call (per-iteration +
+        //                 per-task-event), i.e. the ~8.6M/day churn.
+        //   'throttled' — RECOMMENDED. All 3 presence upserts still fire, but at
+        //                 most once per HEARTBEAT_LIVENESS_INTERVAL_MS per agent.
+        //                 Keeps last_seen / last_active / status fresh for every
+        //                 reader (survivor >10min check, seeder status, dashboards)
+        //                 while collapsing per-iteration/per-event churn to a fixed
+        //                 low cadence (default 2min).
+        //   'off'       — No presence writes at all (UptimeRobot /health end-state).
+        //
+        // Legacy HEARTBEAT_DB_WRITES is mapped onto the new axis for back-compat:
+        //   HEARTBEAT_DB_WRITES=off  ⇒ mode 'off'   (unless HEARTBEAT_MODE is set)
+        //   HEARTBEAT_DB_WRITES=on/  ⇒ mode 'full'  (the historical default)
+        // An explicit HEARTBEAT_MODE always wins over the legacy flag.
+        this.heartbeatMode = resolveHeartbeatMode(process.env.HEARTBEAT_MODE, process.env.HEARTBEAT_DB_WRITES);
+        // Back-compat boolean: true when ANY presence write can occur (full|throttled),
+        // false only in 'off'. Preserved because other code / tests read it.
+        this.heartbeatDbWrites = this.heartbeatMode !== 'off';
+        // Throttle cadence for 'throttled' mode — presence writes fire at most once
+        // per this many ms per agent. Default 120000 (2min) matches the survivor
+        // >10min staleness check (≥5 write windows of headroom) and the heartbeat
+        // setInterval cadence, so readers never see data older than ~2min.
+        this.heartbeatLivenessIntervalMs = parseInt(process.env.HEARTBEAT_LIVENESS_INTERVAL_MS, 10) || 120000;
+        // Timestamp (ms) of the last presence write, for the 'throttled' gate. 0 =
+        // never written this process → first heartbeat() always writes (fresh boot).
+        this._lastPresenceWriteAt = 0;
         // Last-written snapshot of durable registry config, so persistRegistryConfig
         // can write-on-CHANGE only (avoids reintroducing per-loop churn).
         this._lastRegistryConfig = null;
@@ -361,6 +402,12 @@ class ConstitutionalAgentV4 {
         }
     }
 
+    /**
+     * Wall-clock now() in ms — a seam so tests can drive the 'throttled' window
+     * deterministically without real timers. Defaults to Date.now().
+     */
+    _now() { return Date.now(); }
+
     async heartbeat(statusMessage = 'Idle') {
         // Phase 7C — circuit-open early-return. Skip the call entirely if
         // we're in the cool-down window from a recent failure burst. Logged
@@ -383,11 +430,29 @@ class ConstitutionalAgentV4 {
 
             // Presence writes (per-iteration liveness). These are the ~8.6M/day
             // meaningless writes: agent_heartbeat + the trinity_agent_registry /
-            // trinity_heartbeat presence upserts. Gated behind HEARTBEAT_DB_WRITES
-            // (DEFAULT 'on'). When 'off', liveness is delegated to UptimeRobot's
-            // /health polling + the in-memory healthPayload() (loopCount /
-            // lastIterationAt), so hung-loop detection is preserved externally.
-            if (this.heartbeatDbWrites) {
+            // trinity_heartbeat presence upserts. Gated by HEARTBEAT_MODE:
+            //   'full'      → write on every call (default; today's behavior).
+            //   'throttled' → write at most once per heartbeatLivenessIntervalMs
+            //                 per agent — keeps every reader fresh (survivor
+            //                 >10min check, seeder status, dashboards) at a fixed
+            //                 low cadence instead of per-iteration/per-event churn.
+            //   'off'       → never write; liveness delegated to UptimeRobot's
+            //                 /health polling + in-memory healthPayload()
+            //                 (loopCount / lastIterationAt).
+            const now = this._now();
+            let shouldWritePresence = false;
+            if (this.heartbeatMode === 'full') {
+                shouldWritePresence = true;
+            } else if (this.heartbeatMode === 'throttled') {
+                shouldWritePresence =
+                    (now - this._lastPresenceWriteAt) >= this.heartbeatLivenessIntervalMs;
+            }
+            if (shouldWritePresence) {
+                // Record the write time BEFORE issuing upserts so the throttle
+                // window is measured from attempt-start (a slow/failed upsert does
+                // not let the next call bypass the throttle). On failure the outer
+                // catch still runs; the window simply resets on the next success.
+                this._lastPresenceWriteAt = now;
                 // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
                 // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
                 // place of supabase upsert. retries:1 + 10s ceiling preserves the
@@ -2453,5 +2518,9 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
         }
     }
 }
+
+// Attach the pure helper for unit tests (and any external caller that wants the
+// same env→mode resolution). The default export stays the class for back-compat.
+ConstitutionalAgentV4.resolveHeartbeatMode = resolveHeartbeatMode;
 
 module.exports = ConstitutionalAgentV4;

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -172,6 +172,26 @@ class ConstitutionalAgentV4 {
         // (the false-positive that hid Sprint 13's 17h staggered freeze).
         this.loopCount = 0;
 
+        // Presence-write reduction (2026-07): in-memory liveness signal for the
+        // /health endpoint so an external monitor (UptimeRobot keyword check)
+        // can detect a hung loop (loopCount not advancing / stale lastIterationAt)
+        // WITHOUT any DB write. Bumped at the top of every runLoop iteration.
+        this.lastIterationAt = null;
+        // Real deployed commit SHA when running on Railway; falls back to code
+        // version label locally. Surfaced in /health only — no DB write.
+        this.codeVersion = process.env.RAILWAY_GIT_COMMIT_SHA || this.version;
+
+        // HEARTBEAT_DB_WRITES gate (2026-07). DEFAULT 'on' = preserve today's
+        // behavior exactly (per-iteration agent_heartbeat + trinity_agent_registry
+        // presence upserts). Set to 'off' to delegate liveness to UptimeRobot's
+        // /health checks + in-memory loop state and stop the ~8.6M/day meaningless
+        // presence writes. Durable write-on-CHANGE for genuinely-persistent
+        // registry config fields is NOT gated by this flag (see persistRegistryConfig).
+        this.heartbeatDbWrites = (process.env.HEARTBEAT_DB_WRITES || 'on').toLowerCase() !== 'off';
+        // Last-written snapshot of durable registry config, so persistRegistryConfig
+        // can write-on-CHANGE only (avoids reintroducing per-loop churn).
+        this._lastRegistryConfig = null;
+
         // [ANTIGRAVITY] Task Claim Blacklist - prevent infinite retries on problematic tasks
         this.claimHistory = new Map();
         this.MAX_CLAIM_RETRIES = 3;
@@ -244,12 +264,7 @@ class ConstitutionalAgentV4 {
         try {
             const app = express();
             const port = process.env.PORT || 10000;
-            app.get('/health', (req, res) => res.json({
-                status: 'healthy',
-                agent: this.name,
-                version: this.version,
-                timestamp: new Date().toISOString()
-            }));
+            app.get('/health', (req, res) => res.json(this.healthPayload()));
             app.get('*', (req, res) => res.json({
                 status: 'online',
                 agent: this.name,
@@ -259,6 +274,90 @@ class ConstitutionalAgentV4 {
             app.listen(port, '0.0.0.0', () => console.log(`[HEALTH] ✅ Web server listening on 0.0.0.0:${port}`));
         } catch (e) {
             console.error(`[HEALTH] ❌ Failed to start express: ${e.message}`);
+        }
+    }
+
+    /**
+     * In-memory liveness snapshot served by GET /health. Pure read of process
+     * state — performs NO DB access, so it is safe to poll at high frequency
+     * (UptimeRobot). A hung loop is detectable externally: loopCount stops
+     * advancing and lastIterationAt goes stale while the process still answers.
+     * Keyword-monitoring on `"alive":true` + a freshness check on lastIterationAt
+     * replaces the per-iteration agent_heartbeat write when HEARTBEAT_DB_WRITES=off.
+     */
+    healthPayload() {
+        const startTime = (this.sessionMetrics && this.sessionMetrics.startTime) || Date.now();
+        return {
+            alive: true,
+            status: 'healthy',
+            agent: this.name,
+            loopCount: this.loopCount,
+            lastIterationAt: this.lastIterationAt,
+            currentTaskId: this.currentTaskId || null,
+            uptimeSec: Math.floor((Date.now() - startTime) / 1000),
+            codeVersion: this.codeVersion,
+            version: this.version,
+            timestamp: new Date().toISOString()
+        };
+    }
+
+    /**
+     * Durable, write-on-CHANGE persistence for the genuinely-durable
+     * trinity_agent_registry config fields — system_prompt, directive_source,
+     * suggested_prompt (+ suggestion_* siblings), repid_proof, dbt_metadata.
+     *
+     * These are NOT presence/liveness data, so they are deliberately NOT gated
+     * by HEARTBEAT_DB_WRITES: when a value actually changes it must persist,
+     * even with presence writes turned off. To avoid reintroducing per-loop
+     * churn, this only issues an UPDATE when the current snapshot differs from
+     * the last one written (`_lastRegistryConfig`). No-op when nothing changed
+     * or when the runtime hasn't populated any of these fields (today's default).
+     *
+     * NOTE: this repo's runtime does not currently set these fields; the method
+     * is a forward-compatible contract surface so that if/when it does, the
+     * value survives regardless of the presence-write flag.
+     */
+    async persistRegistryConfig(pgOpts = { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY }) {
+        const snapshot = {
+            system_prompt: this.systemPrompt ?? null,
+            directive_source: this.directiveSource ?? null,
+            suggested_prompt: this.suggestedPrompt ?? null,
+            suggestion_status: this.suggestionStatus ?? null,
+            suggestion_source: this.suggestionSource ?? null,
+            repid_proof: this.repidProof ?? null,
+            dbt_metadata: this.dbtMetadata ?? null
+        };
+
+        // Nothing to persist until the runtime actually sets at least one field.
+        const hasAny = Object.values(snapshot).some(v => v !== null && v !== undefined);
+        if (!hasAny) return;
+
+        const serialized = JSON.stringify(snapshot);
+        if (serialized === this._lastRegistryConfig) return; // unchanged → no write
+
+        try {
+            await pgQuery(
+                `INSERT INTO trinity_agent_registry
+                   (agent_name, system_prompt, directive_source, suggested_prompt,
+                    suggestion_status, suggestion_source, repid_proof, dbt_metadata)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+                 ON CONFLICT (agent_name) DO UPDATE SET
+                   system_prompt = EXCLUDED.system_prompt,
+                   directive_source = EXCLUDED.directive_source,
+                   suggested_prompt = EXCLUDED.suggested_prompt,
+                   suggestion_status = EXCLUDED.suggestion_status,
+                   suggestion_source = EXCLUDED.suggestion_source,
+                   repid_proof = EXCLUDED.repid_proof,
+                   dbt_metadata = EXCLUDED.dbt_metadata`,
+                [this.name, snapshot.system_prompt, snapshot.directive_source, snapshot.suggested_prompt,
+                 snapshot.suggestion_status, snapshot.suggestion_source, snapshot.repid_proof,
+                 snapshot.dbt_metadata === null ? null : JSON.stringify(snapshot.dbt_metadata)],
+                { ...pgOpts, label: 'heartbeat:registry_config_on_change' }
+            );
+            this._lastRegistryConfig = serialized;
+        } catch (e) {
+            // Durable-config persistence is best-effort; never break the loop.
+            console.warn(`[${this.name}] persistRegistryConfig non-fatal: ${e?.message ?? e}`);
         }
     }
 
@@ -272,67 +371,82 @@ class ConstitutionalAgentV4 {
 
         const timestamp = new Date().toISOString();
         try {
-            // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
-            // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
-            // place of supabase upsert. retries:1 + 10s ceiling preserves the
-            // prior single-withTimeout latency; pgQuery owns the timeout, and
-            // the method-level heartbeat circuit breaker (below) owns
-            // consecutive-failure handling. Per CLAUDE-RULE-8.
             const taskSummary = this.currentTaskId ? `Working on task ${this.currentTaskId}` : statusMessage;
             const pgOpts = { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY };
 
-            await pgQuery(
-                `INSERT INTO trinity_agent_registry
-                   (agent_name, status, last_active, current_tier, tasks_completed, current_task_summary)
-                 VALUES ($1, $2, $3, $4, $5, $6)
-                 ON CONFLICT (agent_name) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_active = EXCLUDED.last_active,
-                   current_tier = EXCLUDED.current_tier,
-                   tasks_completed = EXCLUDED.tasks_completed,
-                   current_task_summary = EXCLUDED.current_task_summary`,
-                [this.name, 'online', timestamp, this.wisdom.tier || 'specialist', this.sessionMetrics.tasksCompleted, taskSummary],
-                { ...pgOpts, label: 'heartbeat:trinity_agent_registry' }
-            );
+            // Durable write-on-CHANGE for genuinely-persistent registry config
+            // fields (system_prompt, directive_source, suggested_prompt +
+            // suggestion_*, repid_proof, dbt_metadata). NOT gated by
+            // HEARTBEAT_DB_WRITES — these must persist when they actually change,
+            // regardless of the presence-write flag. No-op unless a value changed.
+            await this.persistRegistryConfig(pgOpts);
 
-            // Sprint 14 R-3 — publish the previously-dead instrumentation
-            // columns so the data layer can distinguish loop-alive from
-            // heartbeat-alive. loop_count is owned by the runLoop (incremented
-            // inside the loop body); this writer only publishes it.
-            await pgQuery(
-                `INSERT INTO agent_heartbeat
-                   (agent_name, status, last_ping, loop_count, current_task_id,
-                    tasks_completed_session, tasks_failed_session, code_version, railway_service_id)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                 ON CONFLICT (agent_name) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_ping = EXCLUDED.last_ping,
-                   loop_count = EXCLUDED.loop_count,
-                   current_task_id = EXCLUDED.current_task_id,
-                   tasks_completed_session = EXCLUDED.tasks_completed_session,
-                   tasks_failed_session = EXCLUDED.tasks_failed_session,
-                   code_version = EXCLUDED.code_version,
-                   railway_service_id = EXCLUDED.railway_service_id`,
-                [this.name, 'online', timestamp, this.loopCount, this.currentTaskId || null,
-                 this.sessionMetrics.tasksCompleted, this.sessionMetrics.tasksFailed, this.version, process.env.RAILWAY_SERVICE_ID || null],
-                { ...pgOpts, label: 'heartbeat:agent_heartbeat' }
-            );
+            // Presence writes (per-iteration liveness). These are the ~8.6M/day
+            // meaningless writes: agent_heartbeat + the trinity_agent_registry /
+            // trinity_heartbeat presence upserts. Gated behind HEARTBEAT_DB_WRITES
+            // (DEFAULT 'on'). When 'off', liveness is delegated to UptimeRobot's
+            // /health polling + the in-memory healthPayload() (loopCount /
+            // lastIterationAt), so hung-loop detection is preserved externally.
+            if (this.heartbeatDbWrites) {
+                // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
+                // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
+                // place of supabase upsert. retries:1 + 10s ceiling preserves the
+                // prior single-withTimeout latency; pgQuery owns the timeout, and
+                // the method-level heartbeat circuit breaker (below) owns
+                // consecutive-failure handling. Per CLAUDE-RULE-8.
+                await pgQuery(
+                    `INSERT INTO trinity_agent_registry
+                       (agent_name, status, last_active, current_tier, tasks_completed, current_task_summary)
+                     VALUES ($1, $2, $3, $4, $5, $6)
+                     ON CONFLICT (agent_name) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_active = EXCLUDED.last_active,
+                       current_tier = EXCLUDED.current_tier,
+                       tasks_completed = EXCLUDED.tasks_completed,
+                       current_task_summary = EXCLUDED.current_task_summary`,
+                    [this.name, 'online', timestamp, this.wisdom.tier || 'specialist', this.sessionMetrics.tasksCompleted, taskSummary],
+                    { ...pgOpts, label: 'heartbeat:trinity_agent_registry' }
+                );
 
-            // [ANTIGRAVITY] Sync with trinity_heartbeat for audit-heartbeats compatibility
-            await pgQuery(
-                `INSERT INTO trinity_heartbeat
-                   (agent, status, last_seen, version, current_task_summary, config)
-                 VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-                 ON CONFLICT (agent) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_seen = EXCLUDED.last_seen,
-                   version = EXCLUDED.version,
-                   current_task_summary = EXCLUDED.current_task_summary,
-                   config = EXCLUDED.config`,
-                [this.name, 'online', timestamp, this.version, taskSummary,
-                 JSON.stringify({ group: this.wisdom.squad || 'ORCHESTRATION', tier: this.wisdom.tier || 'specialist' })],
-                { ...pgOpts, label: 'heartbeat:trinity_heartbeat' }
-            );
+                // Sprint 14 R-3 — publish the previously-dead instrumentation
+                // columns so the data layer can distinguish loop-alive from
+                // heartbeat-alive. loop_count is owned by the runLoop (incremented
+                // inside the loop body); this writer only publishes it.
+                await pgQuery(
+                    `INSERT INTO agent_heartbeat
+                       (agent_name, status, last_ping, loop_count, current_task_id,
+                        tasks_completed_session, tasks_failed_session, code_version, railway_service_id)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                     ON CONFLICT (agent_name) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_ping = EXCLUDED.last_ping,
+                       loop_count = EXCLUDED.loop_count,
+                       current_task_id = EXCLUDED.current_task_id,
+                       tasks_completed_session = EXCLUDED.tasks_completed_session,
+                       tasks_failed_session = EXCLUDED.tasks_failed_session,
+                       code_version = EXCLUDED.code_version,
+                       railway_service_id = EXCLUDED.railway_service_id`,
+                    [this.name, 'online', timestamp, this.loopCount, this.currentTaskId || null,
+                     this.sessionMetrics.tasksCompleted, this.sessionMetrics.tasksFailed, this.version, process.env.RAILWAY_SERVICE_ID || null],
+                    { ...pgOpts, label: 'heartbeat:agent_heartbeat' }
+                );
+
+                // [ANTIGRAVITY] Sync with trinity_heartbeat for audit-heartbeats compatibility
+                await pgQuery(
+                    `INSERT INTO trinity_heartbeat
+                       (agent, status, last_seen, version, current_task_summary, config)
+                     VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                     ON CONFLICT (agent) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_seen = EXCLUDED.last_seen,
+                       version = EXCLUDED.version,
+                       current_task_summary = EXCLUDED.current_task_summary,
+                       config = EXCLUDED.config`,
+                    [this.name, 'online', timestamp, this.version, taskSummary,
+                     JSON.stringify({ group: this.wisdom.squad || 'ORCHESTRATION', tier: this.wisdom.tier || 'specialist' })],
+                    { ...pgOpts, label: 'heartbeat:trinity_heartbeat' }
+                );
+            }
 
             // Phase 7C — full success → reset breaker state.
             if (this.consecutiveHeartbeatFailures > 0 || this.heartbeatCircuitOpenLogged) {
@@ -621,6 +735,10 @@ class ConstitutionalAgentV4 {
                 // fresh from the independent setInterval — exactly the signal
                 // missing during the 2026-05-16/17 staggered freeze.
                 this.loopCount++;
+                // In-memory liveness for /health (UptimeRobot). A hung await
+                // leaves this timestamp stale — the external monitor sees it
+                // even with HEARTBEAT_DB_WRITES=off (no DB write required).
+                this.lastIterationAt = new Date().toISOString();
                 const task = await withTimeout(this.getNextTask(), LOOP_TIMEOUTS.DB_QUERY, 'getNextTask');
                 if (!task) {
                     // Phase 2.10: service-contract fulfilment — strictly lower
@@ -720,6 +838,8 @@ class ConstitutionalAgentV4 {
             try {
                 // Sprint 14 R-3 — per-iteration progress counter (see runLoop).
                 this.loopCount++;
+                // In-memory liveness for /health (see runLoop).
+                this.lastIterationAt = new Date().toISOString();
                 const task = await withTimeout(this.getNextTask(), LOOP_TIMEOUTS.DB_QUERY, 'getNextTask');
                 if (task) {
                     console.log(`[${this.name}] 📋 Processing: ${task.title}`);

--- a/tests/heartbeatDbWritesGate.test.js
+++ b/tests/heartbeatDbWritesGate.test.js
@@ -1,0 +1,183 @@
+// HEARTBEAT_DB_WRITES gate + enriched /health payload test for ConstitutionalAgentV4.
+// Run: node tests/heartbeatDbWritesGate.test.js
+//
+// Verifies:
+//  (a) flag ON  (default)  → per-iteration presence writes happen
+//      (trinity_agent_registry + agent_heartbeat + trinity_heartbeat upserts) —
+//      i.e. today's behavior is preserved exactly.
+//  (b) flag OFF → those 3 presence upserts are SKIPPED, but durable
+//      write-on-CHANGE registry config (persistRegistryConfig) still writes
+//      when a durable field changed — regardless of the flag.
+//  (c) persistRegistryConfig writes ONLY on change: a second heartbeat with the
+//      same durable config issues no second config write; changing a value does.
+//  (d) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
+//      currentTaskId/status/uptimeSec/codeVersion present.
+//
+// No jest in this repo (CI runs plain `node tests/*.test.js`). This mirrors the
+// plain-Node style of tests/pulseCheckExecutor.test.js. We stub ./direct-pg in
+// the require cache BEFORE requiring the agent so heartbeat()'s module-level
+// pgQuery is intercepted, and we build the agent via Object.create to skip the
+// real constructor.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Minimal env so incidental createClient()/Redis paths don't crash at require time.
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost';
+process.env.SUPABASE_KEY = process.env.SUPABASE_KEY || 'test-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
+process.env.UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || 'http://localhost';
+process.env.UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || 'test-token';
+
+// --- Stub ./direct-pg in the require cache before the agent module loads. ----
+// heartbeat() / persistRegistryConfig() call the module-scoped pgQuery. We
+// record every call's label so we can assert which writes fired.
+const pgCalls = [];
+function resetPgCalls() { pgCalls.length = 0; }
+const directPgPath = require.resolve('../lib/direct-pg');
+require.cache[directPgPath] = {
+  id: directPgPath,
+  filename: directPgPath,
+  loaded: true,
+  exports: {
+    pgQuery: async (sql, params, opts) => {
+      pgCalls.push({ label: (opts && opts.label) || null, sql, params });
+      return { rows: [], rowCount: 0 };
+    },
+    pgPing: async () => ({ ok: true, latencyMs: 1 })
+  },
+  children: [],
+  paths: []
+};
+
+const ConstitutionalAgentV4 = require('../lib/ConstitutionalAgentV4');
+
+// Build an agent instance without running the real constructor.
+function makeAgent(overrides = {}) {
+  const agent = Object.create(ConstitutionalAgentV4.prototype);
+  agent.name = 'trinity-mel';
+  agent.version = '8.1.3-test';
+  agent.phi = 1.61803398875;
+  agent.loopCount = 3;
+  agent.currentTaskId = null;
+  agent.lastIterationAt = new Date().toISOString();
+  agent.codeVersion = 'deadbeef';
+  agent.sessionMetrics = { tasksCompleted: 2, tasksFailed: 1, llmCalls: 0, startTime: Date.now() - 5000 };
+  agent.wisdom = { squad: 'BETA', tier: 'specialist', primaryVirtue: 'LOVELY' };
+  agent.consecutiveHeartbeatFailures = 0;
+  agent.heartbeatCircuitOpenUntil = 0;
+  agent.heartbeatCircuitOpenLogged = false;
+  agent._lastRegistryConfig = null;
+  agent.heartbeatDbWrites = true; // default ON
+  return Object.assign(agent, overrides);
+}
+
+const PRESENCE_LABELS = [
+  'heartbeat:trinity_agent_registry',
+  'heartbeat:agent_heartbeat',
+  'heartbeat:trinity_heartbeat'
+];
+const CONFIG_LABEL = 'heartbeat:registry_config_on_change';
+
+function labelsFired() { return pgCalls.map(c => c.label); }
+
+let passed = 0, failed = 0;
+async function test(name, fn) {
+  try { await fn(); console.log(`PASS  ${name}`); passed++; }
+  catch (err) { console.error(`FAIL  ${name}`); console.error(`      ${err.stack || err.message}`); failed++; }
+}
+
+(async () => {
+  // (a) flag ON → all 3 presence upserts fire (today's behavior)
+  await test('a) HEARTBEAT_DB_WRITES on → presence writes happen', async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatDbWrites: true });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `expected presence write ${lbl} to fire when flag ON`);
+    }
+    // No durable config set → no config write.
+    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config → no config write');
+  });
+
+  // (b) flag OFF → presence upserts skipped; durable config-on-change still writes
+  await test('b) HEARTBEAT_DB_WRITES off → presence skipped, durable config still writes', async () => {
+    resetPgCalls();
+    const agent = makeAgent({
+      heartbeatDbWrites: false,
+      systemPrompt: 'You are MEL. v1',
+      directiveSource: 'sean',
+      dbtMetadata: { model: 'mel_core' }
+    });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(!fired.includes(lbl), `presence write ${lbl} must be SKIPPED when flag OFF`);
+    }
+    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must still write when a field changed');
+  });
+
+  // (c) config write-on-CHANGE: same config twice → one write; change → new write
+  await test('c) persistRegistryConfig writes only on change', async () => {
+    resetPgCalls();
+    const agent = makeAgent({
+      heartbeatDbWrites: false,
+      systemPrompt: 'prompt A',
+      directiveSource: 'sean'
+    });
+
+    await agent.heartbeat('Idle');
+    let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 1, 'first heartbeat with durable config → exactly one config write');
+
+    // Second heartbeat, no change → no additional config write.
+    await agent.heartbeat('Idle');
+    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 1, 'unchanged durable config → no second config write');
+
+    // Change a durable field → a new config write fires.
+    agent.systemPrompt = 'prompt B';
+    await agent.heartbeat('Idle');
+    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 2, 'changed durable config → a new config write');
+  });
+
+  // (c2) flag ON also persists durable config-on-change (independent of flag)
+  await test('c2) durable config-on-change fires with flag ON too', async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatDbWrites: true, repidProof: '0xproof' });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must fire regardless of flag');
+    // and presence writes still happen when flag ON
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `presence write ${lbl} should still fire when flag ON`);
+    }
+  });
+
+  // (d) healthPayload() shape
+  await test('d) healthPayload() exposes in-memory liveness shape', async () => {
+    const agent = makeAgent({ loopCount: 42, currentTaskId: 'task-7' });
+    const p = agent.healthPayload();
+    assert.equal(p.alive, true, 'alive must be true');
+    assert.equal(p.status, 'healthy');
+    assert.equal(p.agent, 'trinity-mel');
+    assert.equal(p.loopCount, 42);
+    assert.equal(p.currentTaskId, 'task-7');
+    assert.equal(typeof p.lastIterationAt, 'string');
+    assert.equal(typeof p.uptimeSec, 'number');
+    assert.ok(p.uptimeSec >= 0, 'uptimeSec must be non-negative');
+    assert.equal(p.codeVersion, 'deadbeef');
+    assert.ok('version' in p && 'timestamp' in p);
+    // Pure read: healthPayload must not touch the DB.
+    resetPgCalls();
+    agent.healthPayload();
+    assert.equal(pgCalls.length, 0, 'healthPayload must perform no DB writes');
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+})();

--- a/tests/heartbeatDbWritesGate.test.js
+++ b/tests/heartbeatDbWritesGate.test.js
@@ -1,28 +1,33 @@
-// HEARTBEAT_DB_WRITES gate + enriched /health payload test for ConstitutionalAgentV4.
+// HEARTBEAT_MODE tri-state gate + enriched /health payload test for ConstitutionalAgentV4.
 // Run: node tests/heartbeatDbWritesGate.test.js
 //
-// Verifies:
-//  (a) flag ON  (default)  → per-iteration presence writes happen
-//      (trinity_agent_registry + agent_heartbeat + trinity_heartbeat upserts) —
-//      i.e. today's behavior is preserved exactly.
-//  (b) flag OFF → those 3 presence upserts are SKIPPED, but durable
-//      write-on-CHANGE registry config (persistRegistryConfig) still writes
-//      when a durable field changed — regardless of the flag.
-//  (c) persistRegistryConfig writes ONLY on change: a second heartbeat with the
-//      same durable config issues no second config write; changing a value does.
-//  (d) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
-//      currentTaskId/status/uptimeSec/codeVersion present.
+// Verifies the presence-write control (trinity_agent_registry presence +
+// agent_heartbeat + trinity_heartbeat upserts) across all three modes, plus the
+// durable write-on-CHANGE path and /health shape:
+//
+//  (a) mode 'full' (default)  → all 3 presence upserts fire on EVERY heartbeat()
+//      call — today's behavior, preserved exactly.
+//  (b) mode 'throttled'       → presence upserts fire AT MOST ONCE per
+//      heartbeatLivenessIntervalMs per agent: first call writes, calls inside the
+//      window skip, the call after the window writes again.
+//  (c) mode 'off'             → presence upserts NEVER fire.
+//  (d) durable config-on-change (persistRegistryConfig) ALWAYS writes when a
+//      durable field changed, in EVERY mode (never gated), and only on change.
+//  (e) resolveHeartbeatMode legacy mapping: HEARTBEAT_DB_WRITES=off → 'off',
+//      unset/on → 'full'; explicit HEARTBEAT_MODE wins.
+//  (f) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
+//      currentTaskId/status/uptimeSec/codeVersion present, no DB access.
 //
 // No jest in this repo (CI runs plain `node tests/*.test.js`). This mirrors the
 // plain-Node style of tests/pulseCheckExecutor.test.js. We stub ./direct-pg in
 // the require cache BEFORE requiring the agent so heartbeat()'s module-level
 // pgQuery is intercepted, and we build the agent via Object.create to skip the
-// real constructor.
+// real constructor. The 'throttled' window is driven deterministically by
+// overriding the agent's _now() seam (no real timers).
 
 'use strict';
 
 const assert = require('node:assert/strict');
-const path = require('node:path');
 
 // Minimal env so incidental createClient()/Redis paths don't crash at require time.
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost';
@@ -54,8 +59,11 @@ require.cache[directPgPath] = {
 
 const ConstitutionalAgentV4 = require('../lib/ConstitutionalAgentV4');
 
+const LIVENESS_MS = 120000; // default 2min throttle window used in these tests
+
 // Build an agent instance without running the real constructor.
-function makeAgent(overrides = {}) {
+// `clock` is a mutable { t } box so the test drives _now() deterministically.
+function makeAgent(overrides = {}, clock = { t: 1_000_000 }) {
   const agent = Object.create(ConstitutionalAgentV4.prototype);
   agent.name = 'trinity-mel';
   agent.version = '8.1.3-test';
@@ -70,7 +78,13 @@ function makeAgent(overrides = {}) {
   agent.heartbeatCircuitOpenUntil = 0;
   agent.heartbeatCircuitOpenLogged = false;
   agent._lastRegistryConfig = null;
-  agent.heartbeatDbWrites = true; // default ON
+  // Tri-state presence-write config.
+  agent.heartbeatMode = 'full';                 // default
+  agent.heartbeatDbWrites = true;               // back-compat mirror (full|throttled → true)
+  agent.heartbeatLivenessIntervalMs = LIVENESS_MS;
+  agent._lastPresenceWriteAt = 0;
+  // Deterministic clock seam.
+  agent._now = () => clock.t;
   return Object.assign(agent, overrides);
 }
 
@@ -82,6 +96,11 @@ const PRESENCE_LABELS = [
 const CONFIG_LABEL = 'heartbeat:registry_config_on_change';
 
 function labelsFired() { return pgCalls.map(c => c.label); }
+function presenceWriteCount() {
+  // One "presence write" == the trinity_agent_registry upsert (fires once per
+  // presence flush). Counting a single label avoids ×3 arithmetic.
+  return labelsFired().filter(l => l === 'heartbeat:trinity_agent_registry').length;
+}
 
 let passed = 0, failed = 0;
 async function test(name, fn) {
@@ -90,76 +109,117 @@ async function test(name, fn) {
 }
 
 (async () => {
-  // (a) flag ON → all 3 presence upserts fire (today's behavior)
-  await test('a) HEARTBEAT_DB_WRITES on → presence writes happen', async () => {
+  // (a) mode 'full' → all 3 presence upserts fire on EVERY call (today's behavior)
+  await test("a) mode 'full' → presence writes fire on every call", async () => {
     resetPgCalls();
-    const agent = makeAgent({ heartbeatDbWrites: true });
+    const agent = makeAgent({ heartbeatMode: 'full' });
+    await agent.heartbeat('Idle');
+    await agent.heartbeat('Idle'); // no clock advance → 'full' still writes
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `expected presence write ${lbl} in 'full'`);
+    }
+    assert.equal(presenceWriteCount(), 2, "'full' writes presence every call (2 calls → 2 flushes)");
+    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config set → no config write');
+  });
+
+  // (b) mode 'throttled' → at most once per heartbeatLivenessIntervalMs per agent
+  await test("b) mode 'throttled' → presence writes at most once per interval", async () => {
+    resetPgCalls();
+    const clock = { t: 1_000_000 };
+    const agent = makeAgent({ heartbeatMode: 'throttled' }, clock);
+
+    // First call (cold) always writes.
+    await agent.heartbeat('Idle');
+    assert.equal(presenceWriteCount(), 1, 'first throttled call writes (cold start)');
+
+    // Within the window → skipped, no matter how many calls.
+    clock.t += 30_000;  await agent.heartbeat('Idle'); // +30s
+    clock.t += 30_000;  await agent.heartbeat('Idle'); // +60s
+    clock.t += 59_000;  await agent.heartbeat('Idle'); // +119s (still < 120s)
+    assert.equal(presenceWriteCount(), 1, 'calls inside the window are throttled (no extra writes)');
+
+    // Crossing the window → writes again exactly once.
+    clock.t += 2_000;   await agent.heartbeat('Idle'); // +121s ≥ 120s window
+    assert.equal(presenceWriteCount(), 2, 'first call past the window writes again');
+
+    // Immediately after → throttled again.
+    clock.t += 1_000;   await agent.heartbeat('Idle');
+    assert.equal(presenceWriteCount(), 2, 'next call re-enters the throttle window');
+  });
+
+  // (b2) throttled writes ALL THREE presence tables together when it fires
+  await test("b2) mode 'throttled' → a flush writes all 3 presence tables", async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatMode: 'throttled' });
     await agent.heartbeat('Idle');
     const fired = labelsFired();
     for (const lbl of PRESENCE_LABELS) {
-      assert.ok(fired.includes(lbl), `expected presence write ${lbl} to fire when flag ON`);
+      assert.ok(fired.includes(lbl), `throttled flush must write ${lbl} (keeps every reader fresh)`);
     }
-    // No durable config set → no config write.
-    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config → no config write');
   });
 
-  // (b) flag OFF → presence upserts skipped; durable config-on-change still writes
-  await test('b) HEARTBEAT_DB_WRITES off → presence skipped, durable config still writes', async () => {
+  // (c) mode 'off' → presence upserts NEVER fire
+  await test("c) mode 'off' → presence writes never fire", async () => {
     resetPgCalls();
-    const agent = makeAgent({
-      heartbeatDbWrites: false,
-      systemPrompt: 'You are MEL. v1',
-      directiveSource: 'sean',
-      dbtMetadata: { model: 'mel_core' }
-    });
+    const clock = { t: 5_000_000 };
+    const agent = makeAgent({ heartbeatMode: 'off', heartbeatDbWrites: false }, clock);
     await agent.heartbeat('Idle');
-    const fired = labelsFired();
+    clock.t += 10_000_000; // huge advance
+    await agent.heartbeat('Idle');
     for (const lbl of PRESENCE_LABELS) {
-      assert.ok(!fired.includes(lbl), `presence write ${lbl} must be SKIPPED when flag OFF`);
+      assert.ok(!labelsFired().includes(lbl), `presence write ${lbl} must NEVER fire in 'off'`);
     }
-    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must still write when a field changed');
+    assert.equal(presenceWriteCount(), 0, "'off' writes no presence at all");
   });
 
-  // (c) config write-on-CHANGE: same config twice → one write; change → new write
-  await test('c) persistRegistryConfig writes only on change', async () => {
-    resetPgCalls();
-    const agent = makeAgent({
-      heartbeatDbWrites: false,
-      systemPrompt: 'prompt A',
-      directiveSource: 'sean'
-    });
+  // (d) durable config-on-change writes in EVERY mode, only on change
+  await test('d) durable config-on-change always writes (all modes), only on change', async () => {
+    for (const mode of ['full', 'throttled', 'off']) {
+      resetPgCalls();
+      const agent = makeAgent({
+        heartbeatMode: mode,
+        heartbeatDbWrites: mode !== 'off',
+        systemPrompt: 'prompt A',
+        directiveSource: 'sean'
+      });
 
-    await agent.heartbeat('Idle');
-    let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 1, 'first heartbeat with durable config → exactly one config write');
+      await agent.heartbeat('Idle');
+      let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 1, `[${mode}] first heartbeat with durable config → one config write`);
 
-    // Second heartbeat, no change → no additional config write.
-    await agent.heartbeat('Idle');
-    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 1, 'unchanged durable config → no second config write');
+      // Unchanged → no new config write (even as presence throttles/fires independently).
+      await agent.heartbeat('Idle');
+      configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 1, `[${mode}] unchanged durable config → no second config write`);
 
-    // Change a durable field → a new config write fires.
-    agent.systemPrompt = 'prompt B';
-    await agent.heartbeat('Idle');
-    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 2, 'changed durable config → a new config write');
-  });
-
-  // (c2) flag ON also persists durable config-on-change (independent of flag)
-  await test('c2) durable config-on-change fires with flag ON too', async () => {
-    resetPgCalls();
-    const agent = makeAgent({ heartbeatDbWrites: true, repidProof: '0xproof' });
-    await agent.heartbeat('Idle');
-    const fired = labelsFired();
-    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must fire regardless of flag');
-    // and presence writes still happen when flag ON
-    for (const lbl of PRESENCE_LABELS) {
-      assert.ok(fired.includes(lbl), `presence write ${lbl} should still fire when flag ON`);
+      // Change a durable field → new config write, regardless of presence mode.
+      agent.systemPrompt = 'prompt B';
+      await agent.heartbeat('Idle');
+      configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 2, `[${mode}] changed durable config → a new config write`);
     }
   });
 
-  // (d) healthPayload() shape
-  await test('d) healthPayload() exposes in-memory liveness shape', async () => {
+  // (e) resolveHeartbeatMode legacy mapping + precedence
+  await test('e) resolveHeartbeatMode maps legacy flag and honors explicit mode', async () => {
+    const resolve = ConstitutionalAgentV4.resolveHeartbeatMode;
+    assert.equal(typeof resolve, 'function', 'resolveHeartbeatMode must be exported');
+    // Legacy-only mapping.
+    assert.equal(resolve(undefined, undefined), 'full', 'nothing set → full (today default)');
+    assert.equal(resolve(undefined, 'on'), 'full', 'HEARTBEAT_DB_WRITES=on → full');
+    assert.equal(resolve(undefined, 'off'), 'off', 'HEARTBEAT_DB_WRITES=off → off');
+    // Explicit mode wins over legacy.
+    assert.equal(resolve('throttled', 'off'), 'throttled', 'explicit HEARTBEAT_MODE wins over legacy');
+    assert.equal(resolve('FULL', 'off'), 'full', 'mode is case-insensitive');
+    assert.equal(resolve('off', 'on'), 'off', 'explicit off wins over legacy on');
+    // Unrecognized mode falls back to legacy mapping.
+    assert.equal(resolve('bogus', 'off'), 'off', 'unknown mode → legacy fallback (off)');
+    assert.equal(resolve('bogus', undefined), 'full', 'unknown mode + no legacy → full');
+  });
+
+  // (f) healthPayload() shape (unchanged enrichment)
+  await test('f) healthPayload() exposes in-memory liveness shape', async () => {
     const agent = makeAgent({ loopCount: 42, currentTaskId: 'task-7' });
     const p = agent.healthPayload();
     assert.equal(p.alive, true, 'alive must be true');


### PR DESCRIPTION
## What
Eliminates the ~8.6M/day meaningless Supabase presence-write churn from the shared agent runtime, while preserving liveness detection.

## ⚠️ Stacked PR
Based on `feat/xc-2026-06-28-engine-llm-proxy` (the `lib/` single-source consolidation this change sits on top of), which is not yet in `main`. Diff here is **only the 2 heartbeat commits**. Merge after the base lands, or rebase onto `main` once the consolidation is merged.

## Why
`pg_stat_user_tables` (prod overload investigation) showed each agent writing **3 presence upserts** (`trinity_agent_registry` + `agent_heartbeat` + `trinity_heartbeat`) on every loop iteration + task event — ~8.6M/day to ~30 rows, zero retained value.

## Changes (`lib/ConstitutionalAgentV4.js` + tests)
- **`HEARTBEAT_MODE`** = `full` | `throttled` | `off` (default `full` = exact current behavior; legacy `HEARTBEAT_DB_WRITES` still honored).
- **`throttled`** (recommended): the 3 presence upserts fire at most once per `HEARTBEAT_LIVENESS_INTERVAL_MS` (default 2 min) → **~99.7% fewer writes**; `last_seen`/`last_active` stay fresh.
- **`off`**: no presence writes (eventual UptimeRobot-only end-state).
- **Richer `/health`**: exposes in-memory `loopCount`/`lastIterationAt`/`currentTaskId` so UptimeRobot detects a hung loop with **zero DB writes**.
- Durable config-on-change writes unaffected.

## Safety — reader map verified
Every presence reader uses ≥5-min staleness (health-extended/telegram/controller = 5 min; survivor down-detection = 10 min), so a 2-min throttle is *fresher* than any reader needs → safe with **zero repointing**.

## Rollout
Merge-safe (default preserves behavior) → set `HEARTBEAT_MODE=throttled` in Railway to activate the cut.

## Follow-ups (not here)
- Pre-existing bug: evergreen seeder gates on `status='idle'` but nothing ever writes `'idle'` — separate fix.
- Dropping the 3 redundant heartbeat tables — separate migration, after `off` runs green in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)