### PR TITLE
feat(runtime): agent web search + artifact enforcement + peer-verify timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,4 @@ jobs:
           node tests/getNextTask.test.js
           node tests/provenance.test.js
           node tests/pulseCheckExecutor.test.js
+          node tests/heartbeatDbWritesGate.test.js

--- a/lib/ConstitutionalAgent.ts
+++ b/lib/ConstitutionalAgent.ts
@@ -52,8 +52,10 @@ export class WebResearchTool implements ResearchTool {
     async searchWeb(query: string): Promise<{ url: string; title: string; content: string }[]> {
         const apiKey = process.env.TAVILY_API_KEY;
         if (!apiKey) {
-            console.warn('[ResearchTool] ⚠️ No TAVILY_API_KEY. Returning mock.');
-            return [{ url: "https://example.com", title: "Missing API Key", content: "Please set TAVILY_API_KEY." }];
+            // DEGRADE LOUDLY — never fabricate a fake result. Callers already
+            // treat an empty array as "no sources" (searchResults.length === 0).
+            console.warn('[ResearchTool] ⚠️ TAVILY_API_KEY unset — web search DEGRADED (no live sources). Returning [].');
+            return [];
         }
 
         try {
@@ -78,8 +80,9 @@ export class WebResearchTool implements ResearchTool {
                 content: r.content
             }));
         } catch (e: any) {
-            console.error(`[ResearchTool] Error: ${e.message}`);
-            return [{ url: "error", title: "Search Failed", content: e.message }];
+            // DEGRADE LOUDLY — no fabricated "error" row; empty = no sources.
+            console.warn(`[ResearchTool] ⚠️ Tavily search failed (${e.message}) — DEGRADED (no fabricated result).`);
+            return [];
         }
     }
 

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -117,6 +117,22 @@ function canonicalizeProvider(providerKey) {
     return clean;
 }
 
+/**
+ * Resolve the tri-state presence-write mode from the new HEARTBEAT_MODE env and
+ * the legacy HEARTBEAT_DB_WRITES flag. Precedence:
+ *   1. Explicit HEARTBEAT_MODE = full|throttled|off  → wins.
+ *   2. Otherwise map legacy HEARTBEAT_DB_WRITES: 'off' → 'off', anything else → 'full'.
+ *   3. Neither set → 'full' (preserves today's exact default behavior).
+ * Any unrecognized HEARTBEAT_MODE value falls through to the legacy mapping.
+ */
+function resolveHeartbeatMode(modeEnv, legacyEnv) {
+    const mode = (modeEnv || '').toLowerCase().trim();
+    if (mode === 'full' || mode === 'throttled' || mode === 'off') return mode;
+    // Legacy fallback: HEARTBEAT_DB_WRITES=off → off; default (on/unset) → full.
+    const legacy = (legacyEnv || 'on').toLowerCase().trim();
+    return legacy === 'off' ? 'off' : 'full';
+}
+
 class ConstitutionalAgentV4 {
     constructor(config = {}) {
         // PATENT-PENDING: MULTIPLICATIVE_GNN_O(LOG_N) TRUST_SCALING
@@ -182,13 +198,38 @@ class ConstitutionalAgentV4 {
         // version label locally. Surfaced in /health only — no DB write.
         this.codeVersion = process.env.RAILWAY_GIT_COMMIT_SHA || this.version;
 
-        // HEARTBEAT_DB_WRITES gate (2026-07). DEFAULT 'on' = preserve today's
-        // behavior exactly (per-iteration agent_heartbeat + trinity_agent_registry
-        // presence upserts). Set to 'off' to delegate liveness to UptimeRobot's
-        // /health checks + in-memory loop state and stop the ~8.6M/day meaningless
-        // presence writes. Durable write-on-CHANGE for genuinely-persistent
-        // registry config fields is NOT gated by this flag (see persistRegistryConfig).
-        this.heartbeatDbWrites = (process.env.HEARTBEAT_DB_WRITES || 'on').toLowerCase() !== 'off';
+        // HEARTBEAT_MODE tri-state gate (2026-07). Controls ONLY the per-iteration
+        // presence upserts (trinity_agent_registry presence + agent_heartbeat +
+        // trinity_heartbeat). Durable write-on-CHANGE for genuinely-persistent
+        // registry config fields is NEVER gated by this (see persistRegistryConfig).
+        //
+        //   'full'      — DEFAULT. Preserve today's exact behavior: all 3 presence
+        //                 upserts fire on EVERY heartbeat() call (per-iteration +
+        //                 per-task-event), i.e. the ~8.6M/day churn.
+        //   'throttled' — RECOMMENDED. All 3 presence upserts still fire, but at
+        //                 most once per HEARTBEAT_LIVENESS_INTERVAL_MS per agent.
+        //                 Keeps last_seen / last_active / status fresh for every
+        //                 reader (survivor >10min check, seeder status, dashboards)
+        //                 while collapsing per-iteration/per-event churn to a fixed
+        //                 low cadence (default 2min).
+        //   'off'       — No presence writes at all (UptimeRobot /health end-state).
+        //
+        // Legacy HEARTBEAT_DB_WRITES is mapped onto the new axis for back-compat:
+        //   HEARTBEAT_DB_WRITES=off  ⇒ mode 'off'   (unless HEARTBEAT_MODE is set)
+        //   HEARTBEAT_DB_WRITES=on/  ⇒ mode 'full'  (the historical default)
+        // An explicit HEARTBEAT_MODE always wins over the legacy flag.
+        this.heartbeatMode = resolveHeartbeatMode(process.env.HEARTBEAT_MODE, process.env.HEARTBEAT_DB_WRITES);
+        // Back-compat boolean: true when ANY presence write can occur (full|throttled),
+        // false only in 'off'. Preserved because other code / tests read it.
+        this.heartbeatDbWrites = this.heartbeatMode !== 'off';
+        // Throttle cadence for 'throttled' mode — presence writes fire at most once
+        // per this many ms per agent. Default 120000 (2min) matches the survivor
+        // >10min staleness check (≥5 write windows of headroom) and the heartbeat
+        // setInterval cadence, so readers never see data older than ~2min.
+        this.heartbeatLivenessIntervalMs = parseInt(process.env.HEARTBEAT_LIVENESS_INTERVAL_MS, 10) || 120000;
+        // Timestamp (ms) of the last presence write, for the 'throttled' gate. 0 =
+        // never written this process → first heartbeat() always writes (fresh boot).
+        this._lastPresenceWriteAt = 0;
         // Last-written snapshot of durable registry config, so persistRegistryConfig
         // can write-on-CHANGE only (avoids reintroducing per-loop churn).
         this._lastRegistryConfig = null;
@@ -379,6 +420,12 @@ class ConstitutionalAgentV4 {
         }
     }
 
+    /**
+     * Wall-clock now() in ms — a seam so tests can drive the 'throttled' window
+     * deterministically without real timers. Defaults to Date.now().
+     */
+    _now() { return Date.now(); }
+
     async heartbeat(statusMessage = 'Idle') {
         // Phase 7C — circuit-open early-return. Skip the call entirely if
         // we're in the cool-down window from a recent failure burst. Logged
@@ -401,11 +448,29 @@ class ConstitutionalAgentV4 {
 
             // Presence writes (per-iteration liveness). These are the ~8.6M/day
             // meaningless writes: agent_heartbeat + the trinity_agent_registry /
-            // trinity_heartbeat presence upserts. Gated behind HEARTBEAT_DB_WRITES
-            // (DEFAULT 'on'). When 'off', liveness is delegated to UptimeRobot's
-            // /health polling + the in-memory healthPayload() (loopCount /
-            // lastIterationAt), so hung-loop detection is preserved externally.
-            if (this.heartbeatDbWrites) {
+            // trinity_heartbeat presence upserts. Gated by HEARTBEAT_MODE:
+            //   'full'      → write on every call (default; today's behavior).
+            //   'throttled' → write at most once per heartbeatLivenessIntervalMs
+            //                 per agent — keeps every reader fresh (survivor
+            //                 >10min check, seeder status, dashboards) at a fixed
+            //                 low cadence instead of per-iteration/per-event churn.
+            //   'off'       → never write; liveness delegated to UptimeRobot's
+            //                 /health polling + in-memory healthPayload()
+            //                 (loopCount / lastIterationAt).
+            const now = this._now();
+            let shouldWritePresence = false;
+            if (this.heartbeatMode === 'full') {
+                shouldWritePresence = true;
+            } else if (this.heartbeatMode === 'throttled') {
+                shouldWritePresence =
+                    (now - this._lastPresenceWriteAt) >= this.heartbeatLivenessIntervalMs;
+            }
+            if (shouldWritePresence) {
+                // Record the write time BEFORE issuing upserts so the throttle
+                // window is measured from attempt-start (a slow/failed upsert does
+                // not let the next call bypass the throttle). On failure the outer
+                // catch still runs; the window simply resets on the next success.
+                this._lastPresenceWriteAt = now;
                 // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
                 // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
                 // place of supabase upsert. retries:1 + 10s ceiling preserves the
@@ -2491,5 +2556,9 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
         }
     }
 }
+
+// Attach the pure helper for unit tests (and any external caller that wants the
+// same env→mode resolution). The default export stays the class for back-compat.
+ConstitutionalAgentV4.resolveHeartbeatMode = resolveHeartbeatMode;
 
 module.exports = ConstitutionalAgentV4;

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -692,6 +692,7 @@ class ConstitutionalAgentV4 {
                 }
 
                 this.currentTaskId = task.id;
+                this._activeTaskHint = task.task_type || task.title || 'agent';
                 this.lastArtifactId = null; // Reset for Step 6 guard
 
                 // STEP 2: Understand Task
@@ -1588,6 +1589,7 @@ CRITERIA: ${task.success_criteria}
         }
 
         this.currentTaskId = task.id;
+        this._activeTaskHint = task.task_type || task.title || 'agent';
         console.log(`[TASK] Executing: ${task.title}`);
 
         if (task.task_type === 'peer_verify') {
@@ -2143,7 +2145,37 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
         return normalized.startsWith('trinity-') ? normalized : `trinity-${normalized}`;
     }
 
-    async callLLM(prompt) {
+    async callLLM(prompt, options = {}) {
+        // ENGINE_LLM_PROXY (XC 2026-06-28): route through repid-engine for ANFIS + llm_call_log.
+        // Gated off by default; direct providers below remain the fallback on failure or env unset.
+        try {
+            const { canUseProxy, callEngineComplete } = require('./engine-llm-proxy');
+            if (canUseProxy()) {
+                const taskHint = options.task_hint || this._activeTaskHint || 'agent';
+                const res = await callEngineComplete({
+                    agentName: this.name,
+                    prompt,
+                    taskHint,
+                    tierPreference: options.tier_preference || 'auto',
+                });
+                this.sessionMetrics.llmCalls++;
+                logToolCall({
+                    agentName: this.name,
+                    toolName: `llm:engine:${res.provider}`,
+                    toolInput: { prompt_sha256: res.prompt_sha256, provider: res.provider, engine_proxy: true },
+                    toolOutput: res,
+                    repidAtCall: this.reputationScore || 0,
+                    confidenceAtCall: 0.9,
+                    autonomyTier: 'just_do_it',
+                    hitlRequired: false,
+                });
+                console.log(`[${this.name}] ENGINE_LLM_PROXY ok provider=${res.provider} cost=$${res.cost_estimate_usd ?? '?'}`);
+                return res;
+            }
+        } catch (e) {
+            console.warn(`[${this.name}] ENGINE_LLM_PROXY failed, falling back to direct: ${e.message}`);
+        }
+
         for (const providerKey of this.availableProviders) {
             const provider = PROVIDERS[providerKey];
             try {

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -173,6 +173,26 @@ class ConstitutionalAgentV4 {
         // (the false-positive that hid Sprint 13's 17h staggered freeze).
         this.loopCount = 0;
 
+        // Presence-write reduction (2026-07): in-memory liveness signal for the
+        // /health endpoint so an external monitor (UptimeRobot keyword check)
+        // can detect a hung loop (loopCount not advancing / stale lastIterationAt)
+        // WITHOUT any DB write. Bumped at the top of every runLoop iteration.
+        this.lastIterationAt = null;
+        // Real deployed commit SHA when running on Railway; falls back to code
+        // version label locally. Surfaced in /health only — no DB write.
+        this.codeVersion = process.env.RAILWAY_GIT_COMMIT_SHA || this.version;
+
+        // HEARTBEAT_DB_WRITES gate (2026-07). DEFAULT 'on' = preserve today's
+        // behavior exactly (per-iteration agent_heartbeat + trinity_agent_registry
+        // presence upserts). Set to 'off' to delegate liveness to UptimeRobot's
+        // /health checks + in-memory loop state and stop the ~8.6M/day meaningless
+        // presence writes. Durable write-on-CHANGE for genuinely-persistent
+        // registry config fields is NOT gated by this flag (see persistRegistryConfig).
+        this.heartbeatDbWrites = (process.env.HEARTBEAT_DB_WRITES || 'on').toLowerCase() !== 'off';
+        // Last-written snapshot of durable registry config, so persistRegistryConfig
+        // can write-on-CHANGE only (avoids reintroducing per-loop churn).
+        this._lastRegistryConfig = null;
+
         // [ANTIGRAVITY] Task Claim Blacklist - prevent infinite retries on problematic tasks
         this.claimHistory = new Map();
         this.MAX_CLAIM_RETRIES = 3;
@@ -262,12 +282,7 @@ class ConstitutionalAgentV4 {
         try {
             const app = express();
             const port = process.env.PORT || 10000;
-            app.get('/health', (req, res) => res.json({
-                status: 'healthy',
-                agent: this.name,
-                version: this.version,
-                timestamp: new Date().toISOString()
-            }));
+            app.get('/health', (req, res) => res.json(this.healthPayload()));
             app.get('*', (req, res) => res.json({
                 status: 'online',
                 agent: this.name,
@@ -277,6 +292,90 @@ class ConstitutionalAgentV4 {
             app.listen(port, '0.0.0.0', () => console.log(`[HEALTH] ✅ Web server listening on 0.0.0.0:${port}`));
         } catch (e) {
             console.error(`[HEALTH] ❌ Failed to start express: ${e.message}`);
+        }
+    }
+
+    /**
+     * In-memory liveness snapshot served by GET /health. Pure read of process
+     * state — performs NO DB access, so it is safe to poll at high frequency
+     * (UptimeRobot). A hung loop is detectable externally: loopCount stops
+     * advancing and lastIterationAt goes stale while the process still answers.
+     * Keyword-monitoring on `"alive":true` + a freshness check on lastIterationAt
+     * replaces the per-iteration agent_heartbeat write when HEARTBEAT_DB_WRITES=off.
+     */
+    healthPayload() {
+        const startTime = (this.sessionMetrics && this.sessionMetrics.startTime) || Date.now();
+        return {
+            alive: true,
+            status: 'healthy',
+            agent: this.name,
+            loopCount: this.loopCount,
+            lastIterationAt: this.lastIterationAt,
+            currentTaskId: this.currentTaskId || null,
+            uptimeSec: Math.floor((Date.now() - startTime) / 1000),
+            codeVersion: this.codeVersion,
+            version: this.version,
+            timestamp: new Date().toISOString()
+        };
+    }
+
+    /**
+     * Durable, write-on-CHANGE persistence for the genuinely-durable
+     * trinity_agent_registry config fields — system_prompt, directive_source,
+     * suggested_prompt (+ suggestion_* siblings), repid_proof, dbt_metadata.
+     *
+     * These are NOT presence/liveness data, so they are deliberately NOT gated
+     * by HEARTBEAT_DB_WRITES: when a value actually changes it must persist,
+     * even with presence writes turned off. To avoid reintroducing per-loop
+     * churn, this only issues an UPDATE when the current snapshot differs from
+     * the last one written (`_lastRegistryConfig`). No-op when nothing changed
+     * or when the runtime hasn't populated any of these fields (today's default).
+     *
+     * NOTE: this repo's runtime does not currently set these fields; the method
+     * is a forward-compatible contract surface so that if/when it does, the
+     * value survives regardless of the presence-write flag.
+     */
+    async persistRegistryConfig(pgOpts = { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY }) {
+        const snapshot = {
+            system_prompt: this.systemPrompt ?? null,
+            directive_source: this.directiveSource ?? null,
+            suggested_prompt: this.suggestedPrompt ?? null,
+            suggestion_status: this.suggestionStatus ?? null,
+            suggestion_source: this.suggestionSource ?? null,
+            repid_proof: this.repidProof ?? null,
+            dbt_metadata: this.dbtMetadata ?? null
+        };
+
+        // Nothing to persist until the runtime actually sets at least one field.
+        const hasAny = Object.values(snapshot).some(v => v !== null && v !== undefined);
+        if (!hasAny) return;
+
+        const serialized = JSON.stringify(snapshot);
+        if (serialized === this._lastRegistryConfig) return; // unchanged → no write
+
+        try {
+            await pgQuery(
+                `INSERT INTO trinity_agent_registry
+                   (agent_name, system_prompt, directive_source, suggested_prompt,
+                    suggestion_status, suggestion_source, repid_proof, dbt_metadata)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+                 ON CONFLICT (agent_name) DO UPDATE SET
+                   system_prompt = EXCLUDED.system_prompt,
+                   directive_source = EXCLUDED.directive_source,
+                   suggested_prompt = EXCLUDED.suggested_prompt,
+                   suggestion_status = EXCLUDED.suggestion_status,
+                   suggestion_source = EXCLUDED.suggestion_source,
+                   repid_proof = EXCLUDED.repid_proof,
+                   dbt_metadata = EXCLUDED.dbt_metadata`,
+                [this.name, snapshot.system_prompt, snapshot.directive_source, snapshot.suggested_prompt,
+                 snapshot.suggestion_status, snapshot.suggestion_source, snapshot.repid_proof,
+                 snapshot.dbt_metadata === null ? null : JSON.stringify(snapshot.dbt_metadata)],
+                { ...pgOpts, label: 'heartbeat:registry_config_on_change' }
+            );
+            this._lastRegistryConfig = serialized;
+        } catch (e) {
+            // Durable-config persistence is best-effort; never break the loop.
+            console.warn(`[${this.name}] persistRegistryConfig non-fatal: ${e?.message ?? e}`);
         }
     }
 
@@ -290,67 +389,82 @@ class ConstitutionalAgentV4 {
 
         const timestamp = new Date().toISOString();
         try {
-            // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
-            // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
-            // place of supabase upsert. retries:1 + 10s ceiling preserves the
-            // prior single-withTimeout latency; pgQuery owns the timeout, and
-            // the method-level heartbeat circuit breaker (below) owns
-            // consecutive-failure handling. Per CLAUDE-RULE-8.
             const taskSummary = this.currentTaskId ? `Working on task ${this.currentTaskId}` : statusMessage;
             const pgOpts = { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY };
 
-            await pgQuery(
-                `INSERT INTO trinity_agent_registry
-                   (agent_name, status, last_active, current_tier, tasks_completed, current_task_summary)
-                 VALUES ($1, $2, $3, $4, $5, $6)
-                 ON CONFLICT (agent_name) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_active = EXCLUDED.last_active,
-                   current_tier = EXCLUDED.current_tier,
-                   tasks_completed = EXCLUDED.tasks_completed,
-                   current_task_summary = EXCLUDED.current_task_summary`,
-                [this.name, 'online', timestamp, this.wisdom.tier || 'specialist', this.sessionMetrics.tasksCompleted, taskSummary],
-                { ...pgOpts, label: 'heartbeat:trinity_agent_registry' }
-            );
+            // Durable write-on-CHANGE for genuinely-persistent registry config
+            // fields (system_prompt, directive_source, suggested_prompt +
+            // suggestion_*, repid_proof, dbt_metadata). NOT gated by
+            // HEARTBEAT_DB_WRITES — these must persist when they actually change,
+            // regardless of the presence-write flag. No-op unless a value changed.
+            await this.persistRegistryConfig(pgOpts);
 
-            // Sprint 14 R-3 — publish the previously-dead instrumentation
-            // columns so the data layer can distinguish loop-alive from
-            // heartbeat-alive. loop_count is owned by the runLoop (incremented
-            // inside the loop body); this writer only publishes it.
-            await pgQuery(
-                `INSERT INTO agent_heartbeat
-                   (agent_name, status, last_ping, loop_count, current_task_id,
-                    tasks_completed_session, tasks_failed_session, code_version, railway_service_id)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                 ON CONFLICT (agent_name) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_ping = EXCLUDED.last_ping,
-                   loop_count = EXCLUDED.loop_count,
-                   current_task_id = EXCLUDED.current_task_id,
-                   tasks_completed_session = EXCLUDED.tasks_completed_session,
-                   tasks_failed_session = EXCLUDED.tasks_failed_session,
-                   code_version = EXCLUDED.code_version,
-                   railway_service_id = EXCLUDED.railway_service_id`,
-                [this.name, 'online', timestamp, this.loopCount, this.currentTaskId || null,
-                 this.sessionMetrics.tasksCompleted, this.sessionMetrics.tasksFailed, this.version, process.env.RAILWAY_SERVICE_ID || null],
-                { ...pgOpts, label: 'heartbeat:agent_heartbeat' }
-            );
+            // Presence writes (per-iteration liveness). These are the ~8.6M/day
+            // meaningless writes: agent_heartbeat + the trinity_agent_registry /
+            // trinity_heartbeat presence upserts. Gated behind HEARTBEAT_DB_WRITES
+            // (DEFAULT 'on'). When 'off', liveness is delegated to UptimeRobot's
+            // /health polling + the in-memory healthPayload() (loopCount /
+            // lastIterationAt), so hung-loop detection is preserved externally.
+            if (this.heartbeatDbWrites) {
+                // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
+                // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
+                // place of supabase upsert. retries:1 + 10s ceiling preserves the
+                // prior single-withTimeout latency; pgQuery owns the timeout, and
+                // the method-level heartbeat circuit breaker (below) owns
+                // consecutive-failure handling. Per CLAUDE-RULE-8.
+                await pgQuery(
+                    `INSERT INTO trinity_agent_registry
+                       (agent_name, status, last_active, current_tier, tasks_completed, current_task_summary)
+                     VALUES ($1, $2, $3, $4, $5, $6)
+                     ON CONFLICT (agent_name) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_active = EXCLUDED.last_active,
+                       current_tier = EXCLUDED.current_tier,
+                       tasks_completed = EXCLUDED.tasks_completed,
+                       current_task_summary = EXCLUDED.current_task_summary`,
+                    [this.name, 'online', timestamp, this.wisdom.tier || 'specialist', this.sessionMetrics.tasksCompleted, taskSummary],
+                    { ...pgOpts, label: 'heartbeat:trinity_agent_registry' }
+                );
 
-            // [ANTIGRAVITY] Sync with trinity_heartbeat for audit-heartbeats compatibility
-            await pgQuery(
-                `INSERT INTO trinity_heartbeat
-                   (agent, status, last_seen, version, current_task_summary, config)
-                 VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-                 ON CONFLICT (agent) DO UPDATE SET
-                   status = EXCLUDED.status,
-                   last_seen = EXCLUDED.last_seen,
-                   version = EXCLUDED.version,
-                   current_task_summary = EXCLUDED.current_task_summary,
-                   config = EXCLUDED.config`,
-                [this.name, 'online', timestamp, this.version, taskSummary,
-                 JSON.stringify({ group: this.wisdom.squad || 'ORCHESTRATION', tier: this.wisdom.tier || 'specialist' })],
-                { ...pgOpts, label: 'heartbeat:trinity_heartbeat' }
-            );
+                // Sprint 14 R-3 — publish the previously-dead instrumentation
+                // columns so the data layer can distinguish loop-alive from
+                // heartbeat-alive. loop_count is owned by the runLoop (incremented
+                // inside the loop body); this writer only publishes it.
+                await pgQuery(
+                    `INSERT INTO agent_heartbeat
+                       (agent_name, status, last_ping, loop_count, current_task_id,
+                        tasks_completed_session, tasks_failed_session, code_version, railway_service_id)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                     ON CONFLICT (agent_name) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_ping = EXCLUDED.last_ping,
+                       loop_count = EXCLUDED.loop_count,
+                       current_task_id = EXCLUDED.current_task_id,
+                       tasks_completed_session = EXCLUDED.tasks_completed_session,
+                       tasks_failed_session = EXCLUDED.tasks_failed_session,
+                       code_version = EXCLUDED.code_version,
+                       railway_service_id = EXCLUDED.railway_service_id`,
+                    [this.name, 'online', timestamp, this.loopCount, this.currentTaskId || null,
+                     this.sessionMetrics.tasksCompleted, this.sessionMetrics.tasksFailed, this.version, process.env.RAILWAY_SERVICE_ID || null],
+                    { ...pgOpts, label: 'heartbeat:agent_heartbeat' }
+                );
+
+                // [ANTIGRAVITY] Sync with trinity_heartbeat for audit-heartbeats compatibility
+                await pgQuery(
+                    `INSERT INTO trinity_heartbeat
+                       (agent, status, last_seen, version, current_task_summary, config)
+                     VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                     ON CONFLICT (agent) DO UPDATE SET
+                       status = EXCLUDED.status,
+                       last_seen = EXCLUDED.last_seen,
+                       version = EXCLUDED.version,
+                       current_task_summary = EXCLUDED.current_task_summary,
+                       config = EXCLUDED.config`,
+                    [this.name, 'online', timestamp, this.version, taskSummary,
+                     JSON.stringify({ group: this.wisdom.squad || 'ORCHESTRATION', tier: this.wisdom.tier || 'specialist' })],
+                    { ...pgOpts, label: 'heartbeat:trinity_heartbeat' }
+                );
+            }
 
             // Phase 7C — full success → reset breaker state.
             if (this.consecutiveHeartbeatFailures > 0 || this.heartbeatCircuitOpenLogged) {
@@ -639,6 +753,12 @@ class ConstitutionalAgentV4 {
                 // fresh from the independent setInterval — exactly the signal
                 // missing during the 2026-05-16/17 staggered freeze.
                 this.loopCount++;
+                // In-memory liveness for /health (UptimeRobot). A hung await
+                // leaves this timestamp stale — the external monitor sees it
+                // even with HEARTBEAT_DB_WRITES=off (no DB write required).
+                // Set BEFORE the agent_controls gate so /health stays fresh
+                // while the agent is intentionally idled (heartbeat-only).
+                this.lastIterationAt = new Date().toISOString();
                 if (!(await this.isWorkEnabled())) {
                     console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
                     await this.idleWhenDisabled();
@@ -743,6 +863,9 @@ class ConstitutionalAgentV4 {
             try {
                 // Sprint 14 R-3 — per-iteration progress counter (see runLoop).
                 this.loopCount++;
+                // In-memory liveness for /health (see runLoop). Set BEFORE the
+                // agent_controls gate so /health stays fresh while idled.
+                this.lastIterationAt = new Date().toISOString();
                 if (!(await this.isWorkEnabled())) {
                     console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
                     await this.idleWhenDisabled();

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -23,6 +23,68 @@ const { pgQuery, pgPing } = require('./direct-pg');
 const { isAgentEnabled: readAgentControlEnabled } = require('./agent-controls');
 const { logToolCall } = require('./tool-call-logger'); // S-QUORUM Phase 4 (gated TOOL_CALL_LOGGING)
 
+// ============================================
+// CHANGE 1 — REAL WEB SEARCH TOOL (Tavily)
+// ============================================
+// Prior state: the live JS runtime had NO web/research tool at all; the stub
+// lived only in the un-loaded lib/ConstitutionalAgent.ts and returned a FAKE
+// example.com row when TAVILY_API_KEY was unset. This gives the JS runtime a
+// real search. Contract: with a key set, it performs ONE real Tavily fetch and
+// returns real source URLs. With no key (or on error) it DEGRADES LOUDLY —
+// console.warn + an explicit { degraded:true, reason, results:[] } — never a
+// fabricated result. Callers must treat degraded:true as "no sources".
+const WEB_SEARCH_TIMEOUT_MS = 15_000;
+
+class WebResearchTool {
+    /**
+     * @param {string} query
+     * @returns {Promise<{degraded:boolean, reason?:string, results:{url:string,title:string,content:string}[]}>}
+     */
+    async searchWeb(query) {
+        const apiKey = process.env.TAVILY_API_KEY;
+        if (!apiKey) {
+            console.warn('[ResearchTool] ⚠️ TAVILY_API_KEY unset — web search DEGRADED (no live sources). Set TAVILY_API_KEY to enable real search.');
+            return { degraded: true, reason: 'TAVILY_API_KEY not set', results: [] };
+        }
+        try {
+            console.log(`[ResearchTool] 🔎 Tavily search: "${query}"`);
+            const response = await withTimeout(
+                fetch('https://api.tavily.com/search', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        api_key: apiKey,
+                        query,
+                        search_depth: 'basic',
+                        max_results: 3
+                    })
+                }),
+                WEB_SEARCH_TIMEOUT_MS,
+                'tavily-search'
+            );
+            if (!response.ok) {
+                const body = await response.text().catch(() => '');
+                console.warn(`[ResearchTool] ⚠️ Tavily HTTP ${response.status} — DEGRADED. ${body.slice(0, 200)}`);
+                return { degraded: true, reason: `Tavily HTTP ${response.status}`, results: [] };
+            }
+            const data = await response.json();
+            if (!data || !Array.isArray(data.results)) {
+                console.warn('[ResearchTool] ⚠️ Tavily returned no results array — DEGRADED.');
+                return { degraded: true, reason: 'no results field', results: [] };
+            }
+            const results = data.results.map(r => ({
+                url: r.url,
+                title: r.title,
+                content: r.content
+            }));
+            return { degraded: false, results };
+        } catch (e) {
+            console.warn(`[ResearchTool] ⚠️ Tavily search failed (${e.message}) — DEGRADED (no fabricated result).`);
+            return { degraded: true, reason: e.message, results: [] };
+        }
+    }
+}
+
 // Sprint 14 R-1 — per-call timeout budgets for awaits inside the loop body.
 // Picked from Sprint 13 diagnostic: production observed LLM <10s, Supabase <1s.
 // These values are upper bounds — a hung underlying call now becomes a thrown
@@ -151,6 +213,9 @@ class ConstitutionalAgentV4 {
         };
         this.version = CONSTITUTION.VERSION;
         this.phi = 1.61803398875; // Golden Ratio
+
+        // CHANGE 1 — real web search tool (Tavily; degrades loudly if no key).
+        this.researchTool = new WebResearchTool();
 
         // DB INIT
         const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -1910,8 +1975,25 @@ VIRTUE: ${this.wisdom.primaryVirtue}
                 return await this.handleArtifactRejection(task, guard.artifact, guard.verdict.reason);
             }
 
+            // CHANGE 2 — ARTIFACT ENFORCEMENT (mirrors the DB-side trigger).
+            // For deliverable tasks (requires_external_artifact OR a deliverable
+            // task_type), a task may NOT reach status='done' with no artifact.
+            //  - artifact already saved this run (this.lastArtifactId set by the
+            //    save_artifact tool / smart-parse fallback) → use its db:// url.
+            //  - substantive result text but no artifact → auto-save it now.
+            //  - nothing substantive to save → status 'needs_artifact', not done.
+            const enforcement = await this._enforceArtifact(task, result.output);
+            let finalStatus = 'done'; // default: verification pipeline
+            if (enforcement.artifactUrl) {
+                artifactUrl = enforcement.artifactUrl;
+            }
+            if (enforcement.blocked) {
+                finalStatus = 'needs_artifact';
+                console.warn(`[ARTIFACT_ENFORCE] ⚠️ Task ${task.id} (${task.task_type || 'n/a'}) has no artifact and no substantive output → status='needs_artifact'.`);
+            }
+
             await this.supabase.from('trinity_tasks').update({
-                status: 'done', // Moving to 'done' for verification pipeline
+                status: finalStatus, // 'done' for verification pipeline, or 'needs_artifact' when deliverable produced no artifact
                 result: result.output,
                 artifact_url: artifactUrl,
                 completed_at: new Date().toISOString(),
@@ -2005,32 +2087,109 @@ Where <verdict> is exactly one of: verified, disputed, timeout.
 
 Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
 
-        const result = await this.callLLM(prompt);
+        // CHANGE 3 — wrap the verifier LLM call in a per-call timeout. Prior state:
+        // this callLLM had NO per-call timeout; only the whole-task 30s withTimeout
+        // (LOOP_TIMEOUTS.LLM_OR_INTERNAL) guarded it, and on that timeout processTask's
+        // peer_verify catch marked the task 'failed' but NEVER POSTed a verdict — so the
+        // panel got <3 votes. Now: on timeout/throw we POST verdict='timeout' ourselves,
+        // computing the signature EXACTLY as the success path does (via _postPeerVerdict),
+        // guaranteeing the panel always receives this verifier's vote.
+        let result;
+        try {
+            result = await withTimeout(this.callLLM(prompt), LOOP_TIMEOUTS.LLM_OR_INTERNAL, `peer_verify:callLLM:${queueId}`);
+        } catch (llmErr) {
+            console.warn(`[${this.name}] peer_verify LLM call failed/timed out for queue ${queueId} (${llmErr.message}) → POSTing verdict='timeout' so the panel still gets 3 votes.`);
+            const post = await this._postPeerVerdict(queueId, 'timeout');
+            if (post.alreadyProcessed) {
+                await this.supabase.from('trinity_tasks').update({
+                    status: 'done',
+                    result: `Soft-skipped: Respond API confirmed queue entry ${queueId} was already processed (LLM timeout path).`,
+                    completed_at: new Date().toISOString()
+                }).eq('id', task.id);
+                return;
+            }
+            if (!post.ok) {
+                throw new Error(`Engine respond API call failed with status ${post.status}: ${post.errTxt}`);
+            }
+            await this.supabase.from('trinity_tasks').update({
+                status: 'done',
+                result: `Peer verification submitted verdict: timeout (LLM ${llmErr.name === 'TimeoutError' ? 'timed out' : 'failed'}: ${llmErr.message}). Response ID: ${post.verifierResponseId}`,
+                completed_at: new Date().toISOString(),
+                metadata: {
+                    ...(task.metadata || {}),
+                    peer_verify_verdict: 'timeout',
+                    peer_verify_timeout_reason: llmErr.message
+                }
+            }).eq('id', task.id);
+            console.log(`[${this.name}] Completed peer_verify task ${task.id} via timeout verdict.`);
+            return;
+        }
+
         const verdictMatch = result.output.match(/\[VERDICT\]\s*(verified|disputed|timeout)/i);
         const verdict = verdictMatch ? verdictMatch[1].toLowerCase() : 'timeout';
         console.log(`[${this.name}] Peer verify verdict: ${verdict} for queue ${queueId}`);
 
-        // 3. Generate verifier_response_id
+        // 3–5. POST the verdict (signature computed inside _postPeerVerdict).
+        const post = await this._postPeerVerdict(queueId, verdict);
+        if (post.alreadyProcessed) {
+            console.log(`[${this.name}] Soft-skipping task ${task.id}: respond API returned already processed.`);
+            await this.supabase.from('trinity_tasks').update({
+                status: 'done',
+                result: `Soft-skipped: Respond API confirmed queue entry ${queueId} was already processed.`,
+                completed_at: new Date().toISOString()
+            }).eq('id', task.id);
+            return;
+        }
+        if (!post.ok) {
+            throw new Error(`Engine respond API call failed with status ${post.status}: ${post.errTxt}`);
+        }
+
+        // 6. Update trinity_tasks row status='done'
+        await this.supabase.from('trinity_tasks').update({
+            status: 'done',
+            result: `Peer verification completed with verdict: ${verdict}. Response ID: ${post.verifierResponseId}`,
+            completed_at: new Date().toISOString(),
+            metadata: {
+                ...(task.metadata || {}),
+                provider_used: result.provider,
+                provider: result.provider
+            }
+        }).eq('id', task.id);
+
+        console.log(`[${this.name}] Completed peer_verify task ${task.id}`);
+    }
+
+    /**
+     * CHANGE 3 — POST a peer-verification verdict to repid-engine.
+     * Extracted from processPeerVerifyTask so the success path and the LLM-timeout
+     * path compute the HMAC signature identically. Returns:
+     *   { ok, status, errTxt, alreadyProcessed, verifierResponseId }
+     * Never mutates trinity_tasks (caller owns that) — this only does signature + POST.
+     */
+    async _postPeerVerdict(queueId, verdict) {
         const crypto = require('crypto');
         const verifierResponseId = crypto.randomUUID();
 
-        // 4. Compute HMAC signature
+        // Compute HMAC signature (identical scheme in both success + timeout paths).
         const cleanName = this.name.replace('trinity-', '').toUpperCase().trim();
         const envKey = `${cleanName}_PRIVATE_KEY`;
+        // Preserve main's fail-loud HMAC handling (no weak 'trinity-default-sbt-secret'
+        // fallback): a missing secret THROWS rather than silently signing with a
+        // hardcoded default. Kept inside the branch's _postPeerVerdict refactor so
+        // both the success and LLM-timeout paths sign identically.
         const secretKey = process.env.PEER_VERIFY_HMAC_SECRET || process.env[envKey] || process.env.TRUSTRAILS_HMAC_SECRET;
         if (!secretKey) {
             throw new Error(`Missing peer-verify HMAC secret (${envKey} or PEER_VERIFY_HMAC_SECRET)`);
         }
-        
+
         const dataToSign = `${queueId}:${verifierResponseId}:${verdict}`;
         const signature = crypto.createHmac('sha256', secretKey).update(dataToSign).digest('hex');
 
-        // 5. Call back to repid-engine POST /api/v1/peer-verification/respond
         const baseUrl = process.env.REPID_API_URL || 'http://localhost:3000';
         const respondUrl = `${baseUrl.replace(/\/$/, '')}/api/v1/peer-verification/respond`;
-        
-        console.log(`[${this.name}] Sending verdict to engine: ${respondUrl}`);
+        console.log(`[${this.name}] Sending verdict '${verdict}' to engine: ${respondUrl}`);
         const apiKey = process.env.REPID_API_KEY || 'test-key-123';
+
         const response = await fetch(respondUrl, {
             method: 'POST',
             headers: {
@@ -2048,34 +2207,12 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
 
         if (!response.ok) {
             const errTxt = await response.text();
-            if (response.status === 400 && errTxt.includes('already processed')) {
-                console.log(`[${this.name}] Soft-skipping task ${task.id}: respond API returned already processed.`);
-                await this.supabase.from('trinity_tasks').update({
-                    status: 'done',
-                    result: `Soft-skipped: Respond API confirmed queue entry ${queueId} was already processed.`,
-                    completed_at: new Date().toISOString()
-                }).eq('id', task.id);
-                return;
-            }
-            throw new Error(`Engine respond API call failed with status ${response.status}: ${errTxt}`);
+            const alreadyProcessed = response.status === 400 && errTxt.includes('already processed');
+            return { ok: false, status: response.status, errTxt, alreadyProcessed, verifierResponseId };
         }
-
-        const resData = await response.json();
+        const resData = await response.json().catch(() => ({}));
         console.log(`[${this.name}] Engine response:`, JSON.stringify(resData));
-
-        // 6. Update trinity_tasks row status='done'
-        await this.supabase.from('trinity_tasks').update({
-            status: 'done',
-            result: `Peer verification completed with verdict: ${verdict}. Response ID: ${verifierResponseId}`,
-            completed_at: new Date().toISOString(),
-            metadata: {
-                ...(task.metadata || {}),
-                provider_used: result.provider,
-                provider: result.provider
-            }
-        }).eq('id', task.id);
-
-        console.log(`[${this.name}] Completed peer_verify task ${task.id}`);
+        return { ok: true, status: response.status, errTxt: null, alreadyProcessed: false, verifierResponseId };
     }
 
     async evaluateResult(output, task) {
@@ -2492,6 +2629,67 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
         throw new Error("Max tool loops reached");
     }
 
+    /**
+     * CHANGE 2 — artifact enforcement decision for the completion path.
+     * Mirrors the DB-side trigger so the agent and DB agree. Returns:
+     *   { required, blocked, artifactUrl }
+     *  - required: true if this task_type is a deliverable OR requires_external_artifact.
+     *  - artifactUrl: a db:// url when an artifact exists (already saved this run,
+     *    or auto-saved here from substantive result text). null otherwise.
+     *  - blocked: true when required && no artifact could be produced (caller
+     *    sets status='needs_artifact' instead of 'done').
+     * For non-deliverable tasks this is a no-op ({ required:false, blocked:false }).
+     */
+    async _enforceArtifact(task, output) {
+        const required = ConstitutionalAgentV4.isDeliverableTask(task);
+        if (!required) {
+            return { required: false, blocked: false, artifactUrl: null };
+        }
+        // (a) An artifact was already saved this run (save_artifact tool or the
+        //     smart-parse fallback set this.lastArtifactId during callLLM).
+        if (this.lastArtifactId) {
+            return { required: true, blocked: false, artifactUrl: `db://trinity_artifacts/${this.lastArtifactId}` };
+        }
+        // (b) Substantive result text but no artifact → auto-save it now.
+        const substantive = typeof output === 'string' && output.trim().length >= ConstitutionalAgentV4.MIN_ARTIFACT_CHARS;
+        if (substantive) {
+            const url = await this.saveArtifact(task.id, output, 'report', `Artifact from ${this.name}`);
+            if (url) {
+                console.log(`[ARTIFACT_ENFORCE] 💾 Task ${task.id}: auto-saved result as artifact (${url}).`);
+                return { required: true, blocked: false, artifactUrl: url };
+            }
+            // Save failed (DB error) — do not silently pass a deliverable with no artifact.
+            return { required: true, blocked: true, artifactUrl: null };
+        }
+        // (c) Nothing substantive to save.
+        return { required: true, blocked: true, artifactUrl: null };
+    }
+
+    /**
+     * CHANGE 1 — agent-facing web research helper.
+     * Runs a real Tavily search (via this.researchTool) and returns both the raw
+     * result and a markdown "## Sources" block listing the fetched URLs, so an
+     * agent executing a research/deliverable task can splice real source URLs
+     * into its output. On degrade it returns degraded:true and an explicit,
+     * non-fabricated notice block — callers must NOT treat this as real sources.
+     */
+    async researchWeb(query) {
+        const res = await this.researchTool.searchWeb(query);
+        if (res.degraded) {
+            return {
+                degraded: true,
+                reason: res.reason,
+                results: [],
+                sourcesBlock: `\n\n## Sources\n_Web search unavailable (${res.reason}). No live sources were fetched for this claim._`
+            };
+        }
+        const lines = res.results.map(r => `- [${r.title || r.url}](${r.url})`);
+        const sourcesBlock = res.results.length
+            ? `\n\n## Sources\n${lines.join('\n')}`
+            : `\n\n## Sources\n_No results returned for "${query}"._`;
+        return { degraded: false, results: res.results, sourcesBlock };
+    }
+
     async saveArtifact(taskId, content, type = 'markdown', title = null) {
         let artifactId = null;
         const safeTaskId = String(taskId || 'self-gen-' + Date.now());
@@ -2560,5 +2758,25 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
 // Attach the pure helper for unit tests (and any external caller that wants the
 // same env→mode resolution). The default export stays the class for back-compat.
 ConstitutionalAgentV4.resolveHeartbeatMode = resolveHeartbeatMode;
+
+// CHANGE 1 — expose the web search tool for wiring/tests.
+ConstitutionalAgentV4.WebResearchTool = WebResearchTool;
+
+// CHANGE 2 — deliverable task types that MUST produce an artifact before 'done'.
+// Named canonical set from the task + the codebase's existing artifactType
+// synonyms ('docs','report','artifact') so agent-side and DB-side agree.
+ConstitutionalAgentV4.DELIVERABLE_TASK_TYPES = new Set([
+    'research', 'code', 'analysis', 'audit', 'content',
+    'design', 'data', 'documentation',
+    'docs', 'report', 'artifact'
+]);
+// Minimum result length (chars) that counts as "substantive" enough to auto-save.
+ConstitutionalAgentV4.MIN_ARTIFACT_CHARS = 40;
+// Pure predicate: is this a deliverable task that requires an artifact?
+ConstitutionalAgentV4.isDeliverableTask = function (task) {
+    if (!task) return false;
+    if (task.requires_external_artifact === true) return true;
+    return ConstitutionalAgentV4.DELIVERABLE_TASK_TYPES.has(task.task_type);
+};
 
 module.exports = ConstitutionalAgentV4;

--- a/lib/engine-llm-proxy.js
+++ b/lib/engine-llm-proxy.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * ENGINE_LLM_PROXY — thin client for repid-engine POST /api/v1/llm/complete.
+ *
+ * When ENGINE_LLM_PROXY=true, ConstitutionalAgentV4.callLLM routes here first so
+ * ANFIS + llm_call_log + cost caps apply. Direct provider keys remain the fallback.
+ *
+ * Env:
+ *   ENGINE_LLM_PROXY=true|false   (default off — direct providers)
+ *   REPID_API_URL / ENGINE_URL    engine base (no trailing slash)
+ *   REPID_API_KEY                 agent-scoped key with llm_complete scope
+ */
+
+const { randomUUID, createHash } = require('node:crypto');
+
+function engineBaseUrl() {
+  const raw = process.env.REPID_API_URL || process.env.ENGINE_URL || '';
+  return String(raw).replace(/\/+$/, '');
+}
+
+function isProxyEnabled() {
+  return process.env.ENGINE_LLM_PROXY === 'true';
+}
+
+function canUseProxy() {
+  return isProxyEnabled() && !!engineBaseUrl() && !!process.env.REPID_API_KEY;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.agentName  e.g. trinity-mel
+ * @param {string} opts.prompt
+ * @param {string} [opts.taskHint]
+ * @param {string} [opts.tierPreference]
+ * @param {string} [opts.idempotencyKey]
+ * @returns {Promise<{ output: string, provider: string, tier?: number, tokens_in?: number, tokens_out?: number, cost_estimate_usd?: number, engine_proxy: true }>}
+ */
+async function callEngineComplete(opts) {
+  const base = engineBaseUrl();
+  const apiKey = process.env.REPID_API_KEY;
+  if (!base) throw new Error('REPID_API_URL/ENGINE_URL unset');
+  if (!apiKey) throw new Error('REPID_API_KEY unset');
+
+  const {
+    agentName,
+    prompt,
+    taskHint = 'agent',
+    tierPreference = 'auto',
+    idempotencyKey = randomUUID(),
+  } = opts || {};
+
+  if (!agentName || !prompt) throw new Error('agentName and prompt required');
+
+  const url = `${base}/api/v1/llm/complete`;
+  const body = {
+    prompt: String(prompt),
+    agent_id: agentName,
+    tier_preference: tierPreference,
+    task_hint: taskHint,
+    idempotency_key: idempotencyKey,
+  };
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`engine non-JSON ${res.status}: ${text.slice(0, 300)}`);
+  }
+
+  if (!res.ok) {
+    throw new Error(`engine ${res.status}: ${data.error || data.message || text.slice(0, 200)}`);
+  }
+
+  const answer = data.answer ?? data.output ?? '';
+  if (!answer) throw new Error('engine returned empty answer');
+
+  return {
+    output: String(answer),
+    provider: data.provider || 'engine',
+    tier: data.tier,
+    tokens_in: data.tokens_in,
+    tokens_out: data.tokens_out,
+    cost_estimate_usd: data.cost_estimate_usd,
+    engine_proxy: true,
+    idempotency_key: idempotencyKey,
+    prompt_sha256: createHash('sha256').update(String(prompt)).digest('hex'),
+  };
+}
+
+module.exports = {
+  callEngineComplete,
+  canUseProxy,
+  isProxyEnabled,
+  engineBaseUrl,
+};

--- a/tests/agentToolsEnforcement.test.js
+++ b/tests/agentToolsEnforcement.test.js
@@ -1,0 +1,195 @@
+// Agent tools + enforcement tests for ConstitutionalAgentV4.
+// Run: node tests/agentToolsEnforcement.test.js
+//
+// Covers the three CHANGE areas from feat/cc-2026-07-04-agent-tools-enforcement:
+//   1) WebResearchTool.searchWeb degrades LOUDLY (no fabricated result) with no key.
+//   2) Artifact enforcement: _enforceArtifact + isDeliverableTask predicate — a
+//      deliverable task may not reach 'done' without an artifact; substantive text
+//      is auto-saved; empty text blocks.
+//   3) Peer-verify: _postPeerVerdict computes the HMAC signature deterministically
+//      and reports already-processed; processPeerVerifyTask's LLM-timeout path POSTs
+//      verdict='timeout' so the panel always gets a vote.
+//
+// No jest in this repo (CI runs plain `node tests/*.test.js`). Mirrors the
+// plain-Node style of tests/heartbeatDbWritesGate.test.js: stub network/DB seams,
+// build the agent via Object.create to skip the real constructor.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+
+// Minimal env so incidental createClient()/Redis paths don't crash at require time.
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost';
+process.env.SUPABASE_KEY = process.env.SUPABASE_KEY || 'test-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
+process.env.UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || 'http://localhost';
+process.env.UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || 'test-token';
+// Deterministic HMAC secret for the peer-verdict signature assertion.
+process.env.PEER_VERIFY_HMAC_SECRET = 'unit-test-secret';
+// Ensure the web search tool sees NO key so we test the loud-degrade branch.
+delete process.env.TAVILY_API_KEY;
+
+const ConstitutionalAgentV4 = require('../lib/ConstitutionalAgentV4');
+
+// Build an agent instance without running the real constructor.
+function makeAgent(overrides = {}) {
+  const agent = Object.create(ConstitutionalAgentV4.prototype);
+  agent.name = 'trinity-mel';
+  agent.version = '8.1.3-test';
+  agent.lastArtifactId = null;
+  agent.researchTool = new ConstitutionalAgentV4.WebResearchTool();
+  // Minimal supabase stub: records update() payloads.
+  agent._updates = [];
+  agent.supabase = {
+    from() {
+      return {
+        update(payload) { agent._updates.push(payload); return this; },
+        eq() { return Promise.resolve({ data: null, error: null }); }
+      };
+    }
+  };
+  return Object.assign(agent, overrides);
+}
+
+let passed = 0, failed = 0;
+async function test(name, fn) {
+  try { await fn(); console.log(`PASS  ${name}`); passed++; }
+  catch (err) { console.error(`FAIL  ${name}`); console.error(`      ${err.stack || err.message}`); failed++; }
+}
+
+(async () => {
+  // ---- CHANGE 1: web search degrades loudly ------------------------------
+  await test('1) searchWeb with no TAVILY_API_KEY degrades loudly (no fake result)', async () => {
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (...a) => warnings.push(a.join(' '));
+    try {
+      const tool = new ConstitutionalAgentV4.WebResearchTool();
+      const res = await tool.searchWeb('anything');
+      assert.equal(res.degraded, true, 'must report degraded');
+      assert.deepEqual(res.results, [], 'must return NO fabricated results');
+      assert.match(res.reason, /TAVILY_API_KEY/, 'reason names the missing key');
+      assert.ok(warnings.some(w => /DEGRADED/.test(w)), 'must console.warn loudly');
+    } finally { console.warn = origWarn; }
+  });
+
+  await test('1b) researchWeb produces an explicit non-fabricated Sources block when degraded', async () => {
+    const agent = makeAgent();
+    const r = await agent.researchWeb('quantum widgets');
+    assert.equal(r.degraded, true);
+    assert.deepEqual(r.results, []);
+    assert.match(r.sourcesBlock, /Web search unavailable/, 'degraded sources block must say so, not invent URLs');
+    assert.ok(!/http/.test(r.sourcesBlock), 'degraded block must contain no fabricated URLs');
+  });
+
+  // ---- CHANGE 2: deliverable predicate + artifact enforcement ------------
+  await test('2) isDeliverableTask covers named deliverable types + requires_external_artifact', () => {
+    for (const t of ['research', 'code', 'analysis', 'audit', 'content', 'design', 'data', 'documentation']) {
+      assert.equal(ConstitutionalAgentV4.isDeliverableTask({ task_type: t }), true, `${t} is a deliverable`);
+    }
+    assert.equal(ConstitutionalAgentV4.isDeliverableTask({ task_type: 'peer_verify' }), false, 'peer_verify is NOT a deliverable');
+    assert.equal(ConstitutionalAgentV4.isDeliverableTask({ task_type: 'system' }), false, 'system is NOT a deliverable');
+    assert.equal(ConstitutionalAgentV4.isDeliverableTask({ task_type: 'system', requires_external_artifact: true }), true, 'requires_external_artifact forces deliverable');
+    assert.equal(ConstitutionalAgentV4.isDeliverableTask(null), false, 'null is safe');
+  });
+
+  await test('2a) non-deliverable task is a no-op (never blocked)', async () => {
+    const agent = makeAgent();
+    const e = await agent._enforceArtifact({ id: 1, task_type: 'system' }, 'short');
+    assert.deepEqual(e, { required: false, blocked: false, artifactUrl: null });
+  });
+
+  await test('2b) deliverable WITH existing artifact (lastArtifactId) → not blocked, uses db url', async () => {
+    const agent = makeAgent({ lastArtifactId: 'art-123' });
+    const e = await agent._enforceArtifact({ id: 2, task_type: 'research' }, 'anything');
+    assert.equal(e.blocked, false);
+    assert.equal(e.artifactUrl, 'db://trinity_artifacts/art-123');
+  });
+
+  await test('2c) deliverable with substantive text but NO artifact → auto-saves, not blocked', async () => {
+    const agent = makeAgent();
+    let savedWith = null;
+    agent.saveArtifact = async (taskId, content) => { savedWith = { taskId, content }; return 'db://trinity_artifacts/auto-9'; };
+    const longText = 'x'.repeat(200);
+    const e = await agent._enforceArtifact({ id: 3, task_type: 'code' }, longText);
+    assert.ok(savedWith, 'must call saveArtifact when substantive text has no artifact');
+    assert.equal(savedWith.content, longText);
+    assert.equal(e.blocked, false);
+    assert.equal(e.artifactUrl, 'db://trinity_artifacts/auto-9');
+  });
+
+  await test('2d) deliverable with empty/trivial text and no artifact → BLOCKED (needs_artifact)', async () => {
+    const agent = makeAgent();
+    let called = false;
+    agent.saveArtifact = async () => { called = true; return null; };
+    const e = await agent._enforceArtifact({ id: 4, task_type: 'analysis' }, '   ');
+    assert.equal(called, false, 'nothing substantive → must NOT try to save an empty artifact');
+    assert.equal(e.blocked, true, 'must block completion');
+    assert.equal(e.artifactUrl, null);
+  });
+
+  await test('2e) deliverable with substantive text but saveArtifact fails → BLOCKED (no silent pass)', async () => {
+    const agent = makeAgent();
+    agent.saveArtifact = async () => null; // DB save failed
+    const e = await agent._enforceArtifact({ id: 5, task_type: 'documentation' }, 'y'.repeat(100));
+    assert.equal(e.blocked, true, 'save failure on a deliverable must not silently pass');
+  });
+
+  // ---- CHANGE 3: peer-verdict signature + timeout POST -------------------
+  await test('3) _postPeerVerdict computes the documented HMAC signature and reports ok', async () => {
+    const agent = makeAgent();
+    let sentBody = null;
+    global.fetch = async (url, opts) => { sentBody = JSON.parse(opts.body); return { ok: true, status: 200, json: async () => ({ recorded: true }) }; };
+
+    const post = await agent._postPeerVerdict(42, 'verified');
+    assert.equal(post.ok, true);
+    // Recompute the expected signature the same way the code does.
+    const dataToSign = `42:${sentBody.verifier_response_id}:verified`;
+    const expected = crypto.createHmac('sha256', 'unit-test-secret').update(dataToSign).digest('hex');
+    assert.equal(sentBody.signature, expected, 'signature must match queueId:responseId:verdict HMAC');
+    assert.equal(sentBody.queue_id, 42);
+    assert.equal(sentBody.verifier_agent_id, 'trinity-mel');
+    assert.equal(sentBody.verdict, 'verified');
+  });
+
+  await test('3b) _postPeerVerdict surfaces already-processed (400) without throwing', async () => {
+    const agent = makeAgent();
+    global.fetch = async () => ({ ok: false, status: 400, text: async () => 'queue already processed' });
+    const post = await agent._postPeerVerdict(7, 'timeout');
+    assert.equal(post.ok, false);
+    assert.equal(post.alreadyProcessed, true);
+  });
+
+  await test('3c) processPeerVerifyTask LLM-timeout path POSTs verdict=timeout (panel gets a vote)', async () => {
+    const agent = makeAgent();
+    // Force the verifier LLM call to hang → withTimeout rejects with TimeoutError.
+    agent.callLLM = () => new Promise(() => {});
+    let postedVerdict = null;
+    global.fetch = async (url, opts) => { postedVerdict = JSON.parse(opts.body).verdict; return { ok: true, status: 200, json: async () => ({ recorded: true }) }; };
+
+    // Shrink the timeout for the test by monkeypatching withTimeout's budget via a
+    // fast-rejecting callLLM wrapper: we instead race a short timer ourselves.
+    // Simpler: temporarily override the module timeout by making callLLM reject fast.
+    agent.callLLM = () => Promise.reject(Object.assign(new Error('Timeout after 30000ms: peer_verify'), { name: 'TimeoutError' }));
+
+    const task = { id: 900, metadata: { peer_verification_queue_id: 55 } };
+    // Bypass the queue-claim DB step by pre-stubbing supabase update chain to also
+    // handle the claim .in()/.select(); return a queue entry so we reach the LLM call.
+    agent.supabase = {
+      from() {
+        return {
+          update() { return this; },
+          eq() { return this; },
+          in() { return this; },
+          select: async () => ({ data: [{ id: 55, claim_text: 'x', certainty_at_claim: 0.5 }], error: null })
+        };
+      }
+    };
+    await agent.processPeerVerifyTask(task);
+    assert.equal(postedVerdict, 'timeout', 'timeout path must POST a timeout verdict so the panel receives 3 votes');
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+})();

--- a/tests/engineLlmProxy.test.js
+++ b/tests/engineLlmProxy.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * ENGINE_LLM_PROXY unit tests — no live engine required (fetch mocked).
+ * Run: node tests/engineLlmProxy.test.js
+ */
+
+const assert = require('node:assert/strict');
+
+const ORIG_FETCH = global.fetch;
+const ORIG_ENV = { ...process.env };
+
+function restore() {
+  global.fetch = ORIG_FETCH;
+  process.env = { ...ORIG_ENV };
+}
+
+async function run() {
+  let passed = 0;
+  const test = async (name, fn) => {
+    try {
+      await fn();
+      console.log(`  ok ${name}`);
+      passed++;
+    } catch (e) {
+      console.error(`  FAIL ${name}:`, e.message);
+      process.exitCode = 1;
+    } finally {
+      restore();
+    }
+  };
+
+  await test('canUseProxy false when flag unset', async () => {
+    delete process.env.ENGINE_LLM_PROXY;
+    delete require.cache[require.resolve('../lib/engine-llm-proxy')];
+    const { canUseProxy } = require('../lib/engine-llm-proxy');
+    assert.equal(canUseProxy(), false);
+  });
+
+  await test('canUseProxy true when env complete', async () => {
+    process.env.ENGINE_LLM_PROXY = 'true';
+    process.env.REPID_API_URL = 'https://engine.example';
+    process.env.REPID_API_KEY = 'agent-key-abc';
+    delete require.cache[require.resolve('../lib/engine-llm-proxy')];
+    const { canUseProxy } = require('../lib/engine-llm-proxy');
+    assert.equal(canUseProxy(), true);
+  });
+
+  await test('callEngineComplete maps answer to output', async () => {
+    process.env.REPID_API_URL = 'https://engine.example';
+    process.env.REPID_API_KEY = 'k';
+    global.fetch = async (url, init) => {
+      assert.match(url, /\/api\/v1\/llm\/complete$/);
+      const body = JSON.parse(init.body);
+      assert.equal(body.agent_id, 'trinity-test');
+      assert.equal(body.tier_preference, 'auto');
+      assert.ok(body.idempotency_key);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          answer: 'hello from engine',
+          provider: 'groq',
+          tier: 0,
+          tokens_in: 10,
+          tokens_out: 5,
+          cost_estimate_usd: 0,
+        }),
+      };
+    };
+    delete require.cache[require.resolve('../lib/engine-llm-proxy')];
+    const { callEngineComplete } = require('../lib/engine-llm-proxy');
+    const res = await callEngineComplete({ agentName: 'trinity-test', prompt: 'ping' });
+    assert.equal(res.output, 'hello from engine');
+    assert.equal(res.provider, 'groq');
+    assert.equal(res.engine_proxy, true);
+  });
+
+  await test('callEngineComplete throws on HTTP error', async () => {
+    process.env.REPID_API_URL = 'https://engine.example';
+    process.env.REPID_API_KEY = 'k';
+    global.fetch = async () => ({
+      ok: false,
+      status: 403,
+      text: async () => JSON.stringify({ error: 'API key agent_id mismatch' }),
+    });
+    delete require.cache[require.resolve('../lib/engine-llm-proxy')];
+    const { callEngineComplete } = require('../lib/engine-llm-proxy');
+    await assert.rejects(
+      () => callEngineComplete({ agentName: 'trinity-test', prompt: 'x' }),
+      /403/,
+    );
+  });
+
+  console.log(`\nengineLlmProxy: ${passed} passed`);
+  if (process.exitCode) process.exit(process.exitCode);
+}
+
+run();

--- a/tests/heartbeatDbWritesGate.test.js
+++ b/tests/heartbeatDbWritesGate.test.js
@@ -1,0 +1,183 @@
+// HEARTBEAT_DB_WRITES gate + enriched /health payload test for ConstitutionalAgentV4.
+// Run: node tests/heartbeatDbWritesGate.test.js
+//
+// Verifies:
+//  (a) flag ON  (default)  → per-iteration presence writes happen
+//      (trinity_agent_registry + agent_heartbeat + trinity_heartbeat upserts) —
+//      i.e. today's behavior is preserved exactly.
+//  (b) flag OFF → those 3 presence upserts are SKIPPED, but durable
+//      write-on-CHANGE registry config (persistRegistryConfig) still writes
+//      when a durable field changed — regardless of the flag.
+//  (c) persistRegistryConfig writes ONLY on change: a second heartbeat with the
+//      same durable config issues no second config write; changing a value does.
+//  (d) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
+//      currentTaskId/status/uptimeSec/codeVersion present.
+//
+// No jest in this repo (CI runs plain `node tests/*.test.js`). This mirrors the
+// plain-Node style of tests/pulseCheckExecutor.test.js. We stub ./direct-pg in
+// the require cache BEFORE requiring the agent so heartbeat()'s module-level
+// pgQuery is intercepted, and we build the agent via Object.create to skip the
+// real constructor.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Minimal env so incidental createClient()/Redis paths don't crash at require time.
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost';
+process.env.SUPABASE_KEY = process.env.SUPABASE_KEY || 'test-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
+process.env.UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || 'http://localhost';
+process.env.UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || 'test-token';
+
+// --- Stub ./direct-pg in the require cache before the agent module loads. ----
+// heartbeat() / persistRegistryConfig() call the module-scoped pgQuery. We
+// record every call's label so we can assert which writes fired.
+const pgCalls = [];
+function resetPgCalls() { pgCalls.length = 0; }
+const directPgPath = require.resolve('../lib/direct-pg');
+require.cache[directPgPath] = {
+  id: directPgPath,
+  filename: directPgPath,
+  loaded: true,
+  exports: {
+    pgQuery: async (sql, params, opts) => {
+      pgCalls.push({ label: (opts && opts.label) || null, sql, params });
+      return { rows: [], rowCount: 0 };
+    },
+    pgPing: async () => ({ ok: true, latencyMs: 1 })
+  },
+  children: [],
+  paths: []
+};
+
+const ConstitutionalAgentV4 = require('../lib/ConstitutionalAgentV4');
+
+// Build an agent instance without running the real constructor.
+function makeAgent(overrides = {}) {
+  const agent = Object.create(ConstitutionalAgentV4.prototype);
+  agent.name = 'trinity-mel';
+  agent.version = '8.1.3-test';
+  agent.phi = 1.61803398875;
+  agent.loopCount = 3;
+  agent.currentTaskId = null;
+  agent.lastIterationAt = new Date().toISOString();
+  agent.codeVersion = 'deadbeef';
+  agent.sessionMetrics = { tasksCompleted: 2, tasksFailed: 1, llmCalls: 0, startTime: Date.now() - 5000 };
+  agent.wisdom = { squad: 'BETA', tier: 'specialist', primaryVirtue: 'LOVELY' };
+  agent.consecutiveHeartbeatFailures = 0;
+  agent.heartbeatCircuitOpenUntil = 0;
+  agent.heartbeatCircuitOpenLogged = false;
+  agent._lastRegistryConfig = null;
+  agent.heartbeatDbWrites = true; // default ON
+  return Object.assign(agent, overrides);
+}
+
+const PRESENCE_LABELS = [
+  'heartbeat:trinity_agent_registry',
+  'heartbeat:agent_heartbeat',
+  'heartbeat:trinity_heartbeat'
+];
+const CONFIG_LABEL = 'heartbeat:registry_config_on_change';
+
+function labelsFired() { return pgCalls.map(c => c.label); }
+
+let passed = 0, failed = 0;
+async function test(name, fn) {
+  try { await fn(); console.log(`PASS  ${name}`); passed++; }
+  catch (err) { console.error(`FAIL  ${name}`); console.error(`      ${err.stack || err.message}`); failed++; }
+}
+
+(async () => {
+  // (a) flag ON → all 3 presence upserts fire (today's behavior)
+  await test('a) HEARTBEAT_DB_WRITES on → presence writes happen', async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatDbWrites: true });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `expected presence write ${lbl} to fire when flag ON`);
+    }
+    // No durable config set → no config write.
+    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config → no config write');
+  });
+
+  // (b) flag OFF → presence upserts skipped; durable config-on-change still writes
+  await test('b) HEARTBEAT_DB_WRITES off → presence skipped, durable config still writes', async () => {
+    resetPgCalls();
+    const agent = makeAgent({
+      heartbeatDbWrites: false,
+      systemPrompt: 'You are MEL. v1',
+      directiveSource: 'sean',
+      dbtMetadata: { model: 'mel_core' }
+    });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(!fired.includes(lbl), `presence write ${lbl} must be SKIPPED when flag OFF`);
+    }
+    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must still write when a field changed');
+  });
+
+  // (c) config write-on-CHANGE: same config twice → one write; change → new write
+  await test('c) persistRegistryConfig writes only on change', async () => {
+    resetPgCalls();
+    const agent = makeAgent({
+      heartbeatDbWrites: false,
+      systemPrompt: 'prompt A',
+      directiveSource: 'sean'
+    });
+
+    await agent.heartbeat('Idle');
+    let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 1, 'first heartbeat with durable config → exactly one config write');
+
+    // Second heartbeat, no change → no additional config write.
+    await agent.heartbeat('Idle');
+    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 1, 'unchanged durable config → no second config write');
+
+    // Change a durable field → a new config write fires.
+    agent.systemPrompt = 'prompt B';
+    await agent.heartbeat('Idle');
+    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+    assert.equal(configWrites, 2, 'changed durable config → a new config write');
+  });
+
+  // (c2) flag ON also persists durable config-on-change (independent of flag)
+  await test('c2) durable config-on-change fires with flag ON too', async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatDbWrites: true, repidProof: '0xproof' });
+    await agent.heartbeat('Idle');
+    const fired = labelsFired();
+    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must fire regardless of flag');
+    // and presence writes still happen when flag ON
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `presence write ${lbl} should still fire when flag ON`);
+    }
+  });
+
+  // (d) healthPayload() shape
+  await test('d) healthPayload() exposes in-memory liveness shape', async () => {
+    const agent = makeAgent({ loopCount: 42, currentTaskId: 'task-7' });
+    const p = agent.healthPayload();
+    assert.equal(p.alive, true, 'alive must be true');
+    assert.equal(p.status, 'healthy');
+    assert.equal(p.agent, 'trinity-mel');
+    assert.equal(p.loopCount, 42);
+    assert.equal(p.currentTaskId, 'task-7');
+    assert.equal(typeof p.lastIterationAt, 'string');
+    assert.equal(typeof p.uptimeSec, 'number');
+    assert.ok(p.uptimeSec >= 0, 'uptimeSec must be non-negative');
+    assert.equal(p.codeVersion, 'deadbeef');
+    assert.ok('version' in p && 'timestamp' in p);
+    // Pure read: healthPayload must not touch the DB.
+    resetPgCalls();
+    agent.healthPayload();
+    assert.equal(pgCalls.length, 0, 'healthPayload must perform no DB writes');
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+})();

--- a/tests/heartbeatDbWritesGate.test.js
+++ b/tests/heartbeatDbWritesGate.test.js
@@ -1,28 +1,33 @@
-// HEARTBEAT_DB_WRITES gate + enriched /health payload test for ConstitutionalAgentV4.
+// HEARTBEAT_MODE tri-state gate + enriched /health payload test for ConstitutionalAgentV4.
 // Run: node tests/heartbeatDbWritesGate.test.js
 //
-// Verifies:
-//  (a) flag ON  (default)  → per-iteration presence writes happen
-//      (trinity_agent_registry + agent_heartbeat + trinity_heartbeat upserts) —
-//      i.e. today's behavior is preserved exactly.
-//  (b) flag OFF → those 3 presence upserts are SKIPPED, but durable
-//      write-on-CHANGE registry config (persistRegistryConfig) still writes
-//      when a durable field changed — regardless of the flag.
-//  (c) persistRegistryConfig writes ONLY on change: a second heartbeat with the
-//      same durable config issues no second config write; changing a value does.
-//  (d) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
-//      currentTaskId/status/uptimeSec/codeVersion present.
+// Verifies the presence-write control (trinity_agent_registry presence +
+// agent_heartbeat + trinity_heartbeat upserts) across all three modes, plus the
+// durable write-on-CHANGE path and /health shape:
+//
+//  (a) mode 'full' (default)  → all 3 presence upserts fire on EVERY heartbeat()
+//      call — today's behavior, preserved exactly.
+//  (b) mode 'throttled'       → presence upserts fire AT MOST ONCE per
+//      heartbeatLivenessIntervalMs per agent: first call writes, calls inside the
+//      window skip, the call after the window writes again.
+//  (c) mode 'off'             → presence upserts NEVER fire.
+//  (d) durable config-on-change (persistRegistryConfig) ALWAYS writes when a
+//      durable field changed, in EVERY mode (never gated), and only on change.
+//  (e) resolveHeartbeatMode legacy mapping: HEARTBEAT_DB_WRITES=off → 'off',
+//      unset/on → 'full'; explicit HEARTBEAT_MODE wins.
+//  (f) healthPayload() shape: alive:true + agent/loopCount/lastIterationAt/
+//      currentTaskId/status/uptimeSec/codeVersion present, no DB access.
 //
 // No jest in this repo (CI runs plain `node tests/*.test.js`). This mirrors the
 // plain-Node style of tests/pulseCheckExecutor.test.js. We stub ./direct-pg in
 // the require cache BEFORE requiring the agent so heartbeat()'s module-level
 // pgQuery is intercepted, and we build the agent via Object.create to skip the
-// real constructor.
+// real constructor. The 'throttled' window is driven deterministically by
+// overriding the agent's _now() seam (no real timers).
 
 'use strict';
 
 const assert = require('node:assert/strict');
-const path = require('node:path');
 
 // Minimal env so incidental createClient()/Redis paths don't crash at require time.
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost';
@@ -54,8 +59,11 @@ require.cache[directPgPath] = {
 
 const ConstitutionalAgentV4 = require('../lib/ConstitutionalAgentV4');
 
+const LIVENESS_MS = 120000; // default 2min throttle window used in these tests
+
 // Build an agent instance without running the real constructor.
-function makeAgent(overrides = {}) {
+// `clock` is a mutable { t } box so the test drives _now() deterministically.
+function makeAgent(overrides = {}, clock = { t: 1_000_000 }) {
   const agent = Object.create(ConstitutionalAgentV4.prototype);
   agent.name = 'trinity-mel';
   agent.version = '8.1.3-test';
@@ -70,7 +78,13 @@ function makeAgent(overrides = {}) {
   agent.heartbeatCircuitOpenUntil = 0;
   agent.heartbeatCircuitOpenLogged = false;
   agent._lastRegistryConfig = null;
-  agent.heartbeatDbWrites = true; // default ON
+  // Tri-state presence-write config.
+  agent.heartbeatMode = 'full';                 // default
+  agent.heartbeatDbWrites = true;               // back-compat mirror (full|throttled → true)
+  agent.heartbeatLivenessIntervalMs = LIVENESS_MS;
+  agent._lastPresenceWriteAt = 0;
+  // Deterministic clock seam.
+  agent._now = () => clock.t;
   return Object.assign(agent, overrides);
 }
 
@@ -82,6 +96,11 @@ const PRESENCE_LABELS = [
 const CONFIG_LABEL = 'heartbeat:registry_config_on_change';
 
 function labelsFired() { return pgCalls.map(c => c.label); }
+function presenceWriteCount() {
+  // One "presence write" == the trinity_agent_registry upsert (fires once per
+  // presence flush). Counting a single label avoids ×3 arithmetic.
+  return labelsFired().filter(l => l === 'heartbeat:trinity_agent_registry').length;
+}
 
 let passed = 0, failed = 0;
 async function test(name, fn) {
@@ -90,76 +109,117 @@ async function test(name, fn) {
 }
 
 (async () => {
-  // (a) flag ON → all 3 presence upserts fire (today's behavior)
-  await test('a) HEARTBEAT_DB_WRITES on → presence writes happen', async () => {
+  // (a) mode 'full' → all 3 presence upserts fire on EVERY call (today's behavior)
+  await test("a) mode 'full' → presence writes fire on every call", async () => {
     resetPgCalls();
-    const agent = makeAgent({ heartbeatDbWrites: true });
+    const agent = makeAgent({ heartbeatMode: 'full' });
+    await agent.heartbeat('Idle');
+    await agent.heartbeat('Idle'); // no clock advance → 'full' still writes
+    const fired = labelsFired();
+    for (const lbl of PRESENCE_LABELS) {
+      assert.ok(fired.includes(lbl), `expected presence write ${lbl} in 'full'`);
+    }
+    assert.equal(presenceWriteCount(), 2, "'full' writes presence every call (2 calls → 2 flushes)");
+    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config set → no config write');
+  });
+
+  // (b) mode 'throttled' → at most once per heartbeatLivenessIntervalMs per agent
+  await test("b) mode 'throttled' → presence writes at most once per interval", async () => {
+    resetPgCalls();
+    const clock = { t: 1_000_000 };
+    const agent = makeAgent({ heartbeatMode: 'throttled' }, clock);
+
+    // First call (cold) always writes.
+    await agent.heartbeat('Idle');
+    assert.equal(presenceWriteCount(), 1, 'first throttled call writes (cold start)');
+
+    // Within the window → skipped, no matter how many calls.
+    clock.t += 30_000;  await agent.heartbeat('Idle'); // +30s
+    clock.t += 30_000;  await agent.heartbeat('Idle'); // +60s
+    clock.t += 59_000;  await agent.heartbeat('Idle'); // +119s (still < 120s)
+    assert.equal(presenceWriteCount(), 1, 'calls inside the window are throttled (no extra writes)');
+
+    // Crossing the window → writes again exactly once.
+    clock.t += 2_000;   await agent.heartbeat('Idle'); // +121s ≥ 120s window
+    assert.equal(presenceWriteCount(), 2, 'first call past the window writes again');
+
+    // Immediately after → throttled again.
+    clock.t += 1_000;   await agent.heartbeat('Idle');
+    assert.equal(presenceWriteCount(), 2, 'next call re-enters the throttle window');
+  });
+
+  // (b2) throttled writes ALL THREE presence tables together when it fires
+  await test("b2) mode 'throttled' → a flush writes all 3 presence tables", async () => {
+    resetPgCalls();
+    const agent = makeAgent({ heartbeatMode: 'throttled' });
     await agent.heartbeat('Idle');
     const fired = labelsFired();
     for (const lbl of PRESENCE_LABELS) {
-      assert.ok(fired.includes(lbl), `expected presence write ${lbl} to fire when flag ON`);
+      assert.ok(fired.includes(lbl), `throttled flush must write ${lbl} (keeps every reader fresh)`);
     }
-    // No durable config set → no config write.
-    assert.ok(!fired.includes(CONFIG_LABEL), 'no durable config → no config write');
   });
 
-  // (b) flag OFF → presence upserts skipped; durable config-on-change still writes
-  await test('b) HEARTBEAT_DB_WRITES off → presence skipped, durable config still writes', async () => {
+  // (c) mode 'off' → presence upserts NEVER fire
+  await test("c) mode 'off' → presence writes never fire", async () => {
     resetPgCalls();
-    const agent = makeAgent({
-      heartbeatDbWrites: false,
-      systemPrompt: 'You are MEL. v1',
-      directiveSource: 'sean',
-      dbtMetadata: { model: 'mel_core' }
-    });
+    const clock = { t: 5_000_000 };
+    const agent = makeAgent({ heartbeatMode: 'off', heartbeatDbWrites: false }, clock);
     await agent.heartbeat('Idle');
-    const fired = labelsFired();
+    clock.t += 10_000_000; // huge advance
+    await agent.heartbeat('Idle');
     for (const lbl of PRESENCE_LABELS) {
-      assert.ok(!fired.includes(lbl), `presence write ${lbl} must be SKIPPED when flag OFF`);
+      assert.ok(!labelsFired().includes(lbl), `presence write ${lbl} must NEVER fire in 'off'`);
     }
-    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must still write when a field changed');
+    assert.equal(presenceWriteCount(), 0, "'off' writes no presence at all");
   });
 
-  // (c) config write-on-CHANGE: same config twice → one write; change → new write
-  await test('c) persistRegistryConfig writes only on change', async () => {
-    resetPgCalls();
-    const agent = makeAgent({
-      heartbeatDbWrites: false,
-      systemPrompt: 'prompt A',
-      directiveSource: 'sean'
-    });
+  // (d) durable config-on-change writes in EVERY mode, only on change
+  await test('d) durable config-on-change always writes (all modes), only on change', async () => {
+    for (const mode of ['full', 'throttled', 'off']) {
+      resetPgCalls();
+      const agent = makeAgent({
+        heartbeatMode: mode,
+        heartbeatDbWrites: mode !== 'off',
+        systemPrompt: 'prompt A',
+        directiveSource: 'sean'
+      });
 
-    await agent.heartbeat('Idle');
-    let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 1, 'first heartbeat with durable config → exactly one config write');
+      await agent.heartbeat('Idle');
+      let configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 1, `[${mode}] first heartbeat with durable config → one config write`);
 
-    // Second heartbeat, no change → no additional config write.
-    await agent.heartbeat('Idle');
-    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 1, 'unchanged durable config → no second config write');
+      // Unchanged → no new config write (even as presence throttles/fires independently).
+      await agent.heartbeat('Idle');
+      configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 1, `[${mode}] unchanged durable config → no second config write`);
 
-    // Change a durable field → a new config write fires.
-    agent.systemPrompt = 'prompt B';
-    await agent.heartbeat('Idle');
-    configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
-    assert.equal(configWrites, 2, 'changed durable config → a new config write');
-  });
-
-  // (c2) flag ON also persists durable config-on-change (independent of flag)
-  await test('c2) durable config-on-change fires with flag ON too', async () => {
-    resetPgCalls();
-    const agent = makeAgent({ heartbeatDbWrites: true, repidProof: '0xproof' });
-    await agent.heartbeat('Idle');
-    const fired = labelsFired();
-    assert.ok(fired.includes(CONFIG_LABEL), 'durable config-on-change must fire regardless of flag');
-    // and presence writes still happen when flag ON
-    for (const lbl of PRESENCE_LABELS) {
-      assert.ok(fired.includes(lbl), `presence write ${lbl} should still fire when flag ON`);
+      // Change a durable field → new config write, regardless of presence mode.
+      agent.systemPrompt = 'prompt B';
+      await agent.heartbeat('Idle');
+      configWrites = labelsFired().filter(l => l === CONFIG_LABEL).length;
+      assert.equal(configWrites, 2, `[${mode}] changed durable config → a new config write`);
     }
   });
 
-  // (d) healthPayload() shape
-  await test('d) healthPayload() exposes in-memory liveness shape', async () => {
+  // (e) resolveHeartbeatMode legacy mapping + precedence
+  await test('e) resolveHeartbeatMode maps legacy flag and honors explicit mode', async () => {
+    const resolve = ConstitutionalAgentV4.resolveHeartbeatMode;
+    assert.equal(typeof resolve, 'function', 'resolveHeartbeatMode must be exported');
+    // Legacy-only mapping.
+    assert.equal(resolve(undefined, undefined), 'full', 'nothing set → full (today default)');
+    assert.equal(resolve(undefined, 'on'), 'full', 'HEARTBEAT_DB_WRITES=on → full');
+    assert.equal(resolve(undefined, 'off'), 'off', 'HEARTBEAT_DB_WRITES=off → off');
+    // Explicit mode wins over legacy.
+    assert.equal(resolve('throttled', 'off'), 'throttled', 'explicit HEARTBEAT_MODE wins over legacy');
+    assert.equal(resolve('FULL', 'off'), 'full', 'mode is case-insensitive');
+    assert.equal(resolve('off', 'on'), 'off', 'explicit off wins over legacy on');
+    // Unrecognized mode falls back to legacy mapping.
+    assert.equal(resolve('bogus', 'off'), 'off', 'unknown mode → legacy fallback (off)');
+    assert.equal(resolve('bogus', undefined), 'full', 'unknown mode + no legacy → full');
+  });
+
+  // (f) healthPayload() shape (unchanged enrichment)
+  await test('f) healthPayload() exposes in-memory liveness shape', async () => {
     const agent = makeAgent({ loopCount: 42, currentTaskId: 'task-7' });
     const p = agent.healthPayload();
     assert.equal(p.alive, true, 'alive must be true');


### PR DESCRIPTION
## Three named changes to the live 12-agent runtime (`lib/ConstitutionalAgentV4.js`)
1. **Real web search** — Tavily fetch built into V4.js (the `.ts` `searchWeb` stub isn't even loaded at runtime; live JS had no web tool). Gated on `TAVILY_API_KEY`; unset → loud degrade + empty result, never a fabricated URL. `researchWeb()` returns a real `## Sources` block.
2. **Artifact enforcement** — deliverable tasks (research/code/analysis/… or `requires_external_artifact`) can no longer reach `status='done'` with a null artifact: existing→use it, substantive text→auto-save to trinity_artifacts, nothing→`status='needs_artifact'`. Mirrors the server-side DB trigger.
3. **Peer-verify timeout** — wraps the verifier `callLLM` in `withTimeout`; on timeout/throw it POSTs `verdict='timeout'` so the panel always gets 3 votes (previously the throw/hang case set the task `failed` with no vote → dead panels).

## Verified / notes
- The existing 678 `timeout` rows came from the *unparseable-LLM* fallback; Change 3 closes the *throw/hang* hole. Both paths share `_postPeerVerdict` (identical signatures).
- `'needs_artifact'` **confirmed a valid `trinity_tasks.status`** (added to the CHECK constraint earlier).
- 11/11 new tests pass; `node --check` clean. (Pre-existing `escalation-contract.test.js` uses jest, which this repo lacks — untouched.)

## Deploy (Sean)
Merge + deploy the 12 agent services, and set **`TAVILY_API_KEY`** to enable live search (safe-degraded without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)