### PR TITLE
refactor(db): prefer canonical SUPABASE_SERVICE_ROLE_KEY

### DIFF
--- a/auto_updater.js
+++ b/auto_updater.js
@@ -18,7 +18,7 @@ const path = require('path');
 
 // Initialize Supabase
 const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 let supabase = null;
 

--- a/constitutional-agent-base.js
+++ b/constitutional-agent-base.js
@@ -288,7 +288,7 @@ function canonicalizeProvider(providerKey) {
 
 class ConstitutionalAgent {
   constructor(config = {}) {
-    this.supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY, { realtime: { transport: WebSocket } });
+    this.supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY, { realtime: { transport: WebSocket } });
         console.log('[SUPABASE] ? Client initialized with ws transport (Node ' + process.version + ')');
     this.redis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,

--- a/w3c.index.js
+++ b/w3c.index.js
@@ -40,7 +40,7 @@ const CONFIG = AGENT_CONFIG[AGENT_NAME] || AGENT_CONFIG.HDM;
 // ============================================
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY || '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || '';
 const PORT = process.env.PORT || 10000;
 
 const CONDUCTOR_TENURE_MS = 20 * 60 * 1000;


### PR DESCRIPTION
Completes the DB-key-name collapse across the prod fleet (pairs with repid-engine #187).

Three agent read-sites read the DB secret under an **old name only**, so they'd break if you deleted it:
- `auto_updater.js` — was `SERVICE_KEY`-first
- `constitutional-agent-base.js` — read `SUPABASE_KEY` only
- `w3c.index.js` — read `SERVICE_KEY` only

All three now prefer **`SUPABASE_SERVICE_ROLE_KEY`** with the old names as transition fallbacks. After this + #187 deploy, the whole fleet reads **one** canonical DB-secret name — rotation is a single variable, and `SUPABASE_SERVICE_KEY` / `SUPABASE_KEY` can be deleted. Nothing breaks (both set today; canonical wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)