### PR TITLE
feat(safety): L0 gate 0.4 — global emergency halt reaches the 12 agents (no DDL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           node -c lib/ConstitutionalAgentV4.js
           node -c lib/tool-call-logger.js
+          node -c lib/emergency-halt.js
+          node -c constitutional-agent-base.js
+          node -c trinity-worker.js
           if [ -f lib/getNextTask.js ]; then node -c lib/getNextTask.js; fi
 
       - name: Node tests
@@ -40,3 +43,13 @@ jobs:
           node tests/provenance.test.js
           node tests/pulseCheckExecutor.test.js
           node tests/heartbeatDbWritesGate.test.js
+          # L0 gate 0.4 — the kill switch. The coverage pin FAILS when a new
+          # loop is added without gating it, so it must run on every PR or the
+          # switch silently stops being global (which is how the engine's
+          # version came to cover 3 of 14 loops).
+          node tests/emergency-halt.test.js
+          node tests/emergency-halt-coverage.test.js
+          # agent-controls.test.js already existed and passed but was never in
+          # this list — a test that never runs proves nothing. Added because it
+          # covers the sibling lever the halt composes with.
+          node tests/agent-controls.test.js

--- a/constitutional-agent-base.js
+++ b/constitutional-agent-base.js
@@ -15,6 +15,7 @@ const WebSocket = require('ws');
 const { Redis } = require('@upstash/redis');
 const crypto = require('crypto');
 const Merkle = require('./utils/merkle');
+const { shouldParkForHalt } = require('./lib/emergency-halt'); // L0 gate 0.4 — GLOBAL kill switch
 
 // ============================================
 // THE CONSTITUTION - IMMUTABLE PRINCIPLES
@@ -697,6 +698,10 @@ ${task.description || 'No description provided'}
     setInterval(() => this.askEternalQuestions(), 15 * 60 * 1000);
   }
   async runSelfDiagnostic() {
+    // L0 gate 0.4 — this is not observability: it can trigger a HEALING CASCADE
+    // and writes a genome report. A halt must stop the machine acting on the
+    // system, especially while a human is trying to work on that same system.
+    if (await shouldParkForHalt(`${this.name}:self-diagnostic`)) return;
     console.log(`[${this.name}] 🔍 Running self-diagnostic...`);
 
     try {
@@ -787,6 +792,8 @@ ${task.description || 'No description provided'}
     return allHealthy;
   }
   async askEternalQuestions() {
+    // L0 gate 0.4 — writes `eternal_question` log rows on a 15-min interval.
+    if (await shouldParkForHalt(`${this.name}:eternal-questions`)) return;
     console.log(`[${this.name}] 🙏 Asking the Three Eternal Questions...`);
 
     for (const question of CONSTITUTION.THREE_ETERNAL_QUESTIONS) {
@@ -1338,6 +1345,14 @@ If a task violates the Eight Virtues, refuse it and explain why.`;
 
     while (true) {
       try {
+        // L0 gate 0.4 — GLOBAL emergency halt, checked first: this loop claims
+        // and processes tasks and has NO agent_controls gate of its own, so the
+        // global switch is the only lever that reaches it. 30s re-check so a
+        // resume is picked up promptly, matching the V4 loops' idle cadence.
+        if (await shouldParkForHalt(this.name)) {
+          await this.sleep(30000);
+          continue;
+        }
         if (this.isSabbathTime()) {
           await this.observeSabbath();
           await this.sleep(30 * 60 * 1000);

--- a/docs/BEAT36_AGENT_EMERGENCY_HALT.md
+++ b/docs/BEAT36_AGENT_EMERGENCY_HALT.md
@@ -1,0 +1,108 @@
+# BEAT 36 — the global kill switch reaches the 12 Railway agents (L0 gate 0.4, agent half)
+
+**Repo:** `trinity-symphony-shared` · **Branch:** `feat/cc-2026-07-27-agent-emergency-halt` · **Base:** `origin/main` @ `6824296b`
+**Backlog item:** 0.4 — *"Kill switch — `emergency_halt` bool in `trinity_system_config`, checked every tick; true → workers PARK"*, listed as gating **all autonomy gates**.
+**Companion:** repid-engine PR #216 covers the engine's workers + mutating HTTP. This PR covers the other half — the twelve agents that actually claim and execute work. **Same column, one flip, both halves.**
+**DDL:** none. The column already exists in production.
+
+---
+
+## Why this was the task
+
+Backlog 0.4 is an **L0 precondition** — dependency-earlier than every remaining L2 breaker — and it was only half done. Beat 34 built the switch; Beat 35's verifier found it reached 3 of ~14 engine loops and Beat 35 closed that. But the engine is not where the autonomy is. The **twelve Railway agents** are the producers and consumers of real work, and they live in this repo, where the switch did not exist at all.
+
+A kill switch that stops the engine and leaves twelve agents claiming tasks is not a kill switch.
+
+---
+
+## Check-first, run BEFORE writing the module (Beat 34's recorded mistake was running it after)
+
+**A per-agent lever already exists** — `lib/agent-controls.js`, reading `agent_controls.enabled`, cached, called once per iteration in both V4 loops. It is the right tool for "idle mel while I look at something". It is the **wrong** tool for an emergency, for two measured reasons:
+
+1. **`agent_controls` holds three rows — `mel`, `sophia`, `veritas`** [V sql:2026-07-27], and `readEnabledFromDb` returns **`true` when no row exists**. **Nine of the twelve production agents cannot be stopped by that lever at all** until someone INSERTs a row first — not something an operator discovers mid-incident.
+2. Even fully populated it is twelve flips, not one, and it says nothing about the non-agent producer in this repo.
+
+So this composes with `agent-controls` rather than replacing it, and the header says so. It also **does not refactor it** (CLAUDE-RULE-3): the ~30 lines of cache plumbing are duplicated rather than extracted, and the duplication is named in the module header instead of being quietly resolved into a third convention.
+
+---
+
+## Scope — ENUMERATED, not asserted
+
+Produced by grepping every `while (true)` and `setInterval(` outside `node_modules`/`tests`, then classifying each. Seven loop-bearing files.
+
+**COVERED — 6 call sites across 3 files:**
+
+| File | Loop | Why it must stop |
+|---|---|---|
+| `lib/ConstitutionalAgentV4.js` | `runLoop()` | the escalation-contract loop |
+| `lib/ConstitutionalAgentV4.js` | `runLoopLegacy()` | **11 of 12 agents run this one** |
+| `constitutional-agent-base.js` | main `while (true)` | claims and processes tasks, and has **no `agent_controls` gate of its own** — the global switch is the only lever that reaches it |
+| `constitutional-agent-base.js` | `runSelfDiagnostic()` | can trigger a **healing cascade** and writes a genome report — that is the machine acting on the system a human is trying to work on |
+| `constitutional-agent-base.js` | `askEternalQuestions()` | writes log rows every 15 min |
+| `trinity-worker.js` | `startSeedingLoop()` | **a PRODUCER** — past its threshold it shells out and seeds evergreen tasks. A switch that stops the consumers but not the thing that CREATES work just refills the queue it was meant to drain |
+
+**DELIBERATELY EXEMPT, with reasons:**
+- the `heartbeat()` setIntervals — observability. A halt must stop the machine **acting**, not stop it **reporting**; the operator needs `/health` and `last_ping` to watch the fleet come to rest. Same call the engine made for `providers/health.ts`.
+- `mutual-wake.js` — `fetch(agent.url + '/health')` only; enumerated for writes, there are none.
+
+**NOT WIRED BECAUSE THEY DO NOT RUN — evidence, not assumption:**
+- `trinity.hdm.js` — calls `pollAndExecute`, which is defined **zero** times in the 9-line file; it throws at boot.
+- `trinity-{apm,orch,sophia,hdm,…}.js` — one-line shims that spawn **`scripts/run-agent.js`, which does not exist**.
+- `w3c.index.js` — a full standalone agent loop referenced by no file and no deploy config.
+- `lib/ConstitutionalAgent.ts` — required/imported by nothing.
+
+The live entry point is `server.js` (`npm start`) → `ConstitutionalAgentV4`. **The coverage test asserts each of these dead-file claims is still true**, so reviving one fails CI rather than silently creating an ungated loop.
+
+---
+
+## Design decisions, each with a reason rather than a preference
+
+1. **`enforce` is the DEFAULT, and the mode parser FAILS CLOSED.** Only exact `off`/`shadow` (case/trim-insensitive) weaken it; `of`, `false`, `0`, `disabled`, garbage all resolve to `enforce` and warn once. Other flags guard features that do damage when ON; this one guards the lever that *stops* damage. **You cannot typo the kill switch into being disabled.**
+2. **The gate sits BEFORE the per-agent `agent_controls` gate.** A global stop that runs second can be masked by the first, and the log line would name the wrong cause mid-incident.
+3. **It parks via the existing `idleWhenDisabled()` path**, so heartbeat and liveness keep reporting while work stops — reads stay up on purpose.
+4. **Fail-OPEN on a read error, STICKY once true.** A flaky pooler must not park the fleet; and an operator who pulls the switch during an incident must not have it released *by* the incident. Note this is the inverse of `agent-controls`, which is fail-CLOSED — **deliberate, not inconsistent**: agent-controls already parks the agent when its store is unreachable, so nothing is lost, and making both fail closed would print a misleading "EMERGENCY HALT" for what is really a database blip.
+5. **A missing column is inert + warned once**, so this is safe to deploy before, without, or after a rollback of the DDL.
+6. **No Redis, unlike `agent-controls`.** The switch has to work when infrastructure is misbehaving, and every extra hop is another place a stale `false` can survive. Stated cost: ~0.4 reads/sec against the pooler across all 12 agents.
+7. **The read is bounded** (`EMERGENCY_HALT_TIMEOUT_MS`, default 2000) and the timer is **not `unref`'d** — Beat 34 shipped an unref'd timeout that let a process exit mid-`await` and leave the flag set in production.
+
+---
+
+## Verification
+
+**[V] 12 of 12 mutations killed**, re-measured against the final code. Both harness guards from prior beats are encoded rather than remembered: restore in a `finally`, and a unique marker asserted 0× before / exactly 1× after, else the result is **DISCARDED as NOT-LANDED**.
+
+| Mutation | Result |
+|---|---|
+| delete one V4 gate call (leave the import) | KILLED |
+| move the V4 gate *after* the per-agent gate | KILLED |
+| remove the seeding **producer** gate | KILLED |
+| remove one of the three base-class gates | KILLED |
+| replace a gate with a **comment mentioning it** (vacuity probe) | KILLED |
+| a new **unclassified** loop file appears | KILLED |
+| a **dead file comes back to life** (`trinity.hdm.js`) | KILLED |
+| sticky removed (a failed read LIFTS the halt) | KILLED |
+| mode parser defaults to `off` | KILLED |
+| the read is **unbounded** | KILLED |
+| fail-open removed (a flaky DB parks the fleet) | KILLED |
+| `isHaltTruthy` accepts anything truthy | KILLED |
+
+**[V] All 7 node tests pass** (the 4 already in CI + `agent-controls` + the 2 new ones). **[V] `node -c` clean** on all four touched/added source files. **[V] Zero `MUTMARK` residue on disk and no stray mutant file — checked, not assumed.**
+
+**[V] Live, before building:** `trinity_system_config.emergency_halt` exists as `boolean NOT NULL DEFAULT false` with the three audit columns; the flag is currently **`false`**; `agent_controls` holds exactly **3** rows, all `enabled=true` [sql:2026-07-27].
+
+**[V] Safety of the (attempted) live acceptance, established two ways:** `origin/main` of this repo contains **zero** references to `emergency_halt`/`shouldParkForHalt`, so no deployed agent can read the flag; and the engine's `/health` reports `deployed_commit=a1b6e7f`, which predates the column. Flipping it today is provably inert.
+
+### Two honest limits — stated, not papered over
+
+1. **No live true-state acceptance run this beat.** Beat 34 flipped the flag and watched the engine react; I could not do the equivalent here. The prod `UPDATE` was **blocked by the session's permission classifier**, and I did not work around it — a guard on a production write is doing its job. What that leaves unproven is only the observable *reaction* to a live flip; the flag's storage, type and default are verified above, and the module is unmerged and inert regardless.
+2. **The real `pgQuery` path is exercised by unit tests through an injected fake, not against the live pooler**, because no `DATABASE_URL` is available locally and obtaining one would mean handling a plaintext secret. The residual risk is node-pg's row mapping — mitigated, not eliminated, by the fact that `agent-controls.js` runs an identical `SELECT <bool column> FROM <table> WHERE <pk>` shape in production today. **This should be re-checked once on first deploy.**
+
+---
+
+## Mistakes this beat
+
+- **My mode-parser test asserted the wrong thing and the first run corrected me.** I had put `'ofF '` in the must-enforce list; it trims and lowercases to exactly `off`, which is a legitimate operator typo, not an attack. The code was right and the test was wrong.
+- **The bounded-read test PASSED under the mutation that removed the bound** — my own pin was vacuous, and only the mutation harness found it. Cause: with the fake query never settling and nothing else on the event loop, **Node judged the loop empty and exited 0 inside the `await`**, so the assertions never ran. That is Beat 34's exit-mid-await defect reproduced *in a test* instead of a script. Fixed with a watchdog timer that both keeps the loop alive and rejects. **Third consecutive beat in which a green result was the wrong conclusion** — the pattern is now unmistakable: any pin asserting a safety property must be run against the absence of that property before it is trusted.
+- **Two mutations first reported NOT-LANDED** because these files are CRLF and my patterns used `\n`. The guard caught what would otherwise have been two free passes.
+- I added `agent-controls.test.js` to CI (it existed, passed, and had never run there). Small scope expansion, stated rather than slipped in.
+- **Carried, not fixed:** this repo's `ci.yml` has the same `pull_request: branches: [main]` filter that repid-engine #213 removes, so stacked PRs here would run no checks. Not bundled — it is a separate change with its own blast radius, and this PR is based on `main` so it is unaffected.

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -21,6 +21,7 @@ const substanceGateClient = require('./substance-gate-client');
 const { withTimeout } = require('./withTimeout');
 const { pgQuery, pgPing } = require('./direct-pg');
 const { isAgentEnabled: readAgentControlEnabled } = require('./agent-controls');
+const { shouldParkForHalt } = require('./emergency-halt'); // L0 gate 0.4 — GLOBAL kill switch
 const { logToolCall } = require('./tool-call-logger'); // S-QUORUM Phase 4 (gated TOOL_CALL_LOGGING)
 
 // ============================================
@@ -889,6 +890,15 @@ class ConstitutionalAgentV4 {
                 // Set BEFORE the agent_controls gate so /health stays fresh
                 // while the agent is intentionally idled (heartbeat-only).
                 this.lastIterationAt = new Date().toISOString();
+                // L0 gate 0.4 — GLOBAL emergency halt. Checked BEFORE the
+                // per-agent agent_controls gate for two reasons: the log line
+                // should name the real cause, and agent_controls cannot stop 9
+                // of the 12 agents (no row => enabled). Parks via the SAME idle
+                // path, so heartbeat/liveness keep reporting while work stops.
+                if (await shouldParkForHalt(this.name)) {
+                    await this.idleWhenDisabled('sleeping (EMERGENCY HALT)');
+                    continue;
+                }
                 if (!(await this.isWorkEnabled())) {
                     console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
                     await this.idleWhenDisabled();
@@ -996,6 +1006,13 @@ class ConstitutionalAgentV4 {
                 // In-memory liveness for /health (see runLoop). Set BEFORE the
                 // agent_controls gate so /health stays fresh while idled.
                 this.lastIterationAt = new Date().toISOString();
+                // L0 gate 0.4 — GLOBAL emergency halt (see runLoop for why this
+                // sits ahead of the per-agent gate). 11 of 12 agents run THIS
+                // loop, so omitting it here would leave the switch covering one.
+                if (await shouldParkForHalt(this.name)) {
+                    await this.idleWhenDisabled('sleeping (EMERGENCY HALT)');
+                    continue;
+                }
                 if (!(await this.isWorkEnabled())) {
                     console.log(`[${this.name}] 💤 Disabled via agent_controls — heartbeat only`);
                     await this.idleWhenDisabled();

--- a/lib/emergency-halt.js
+++ b/lib/emergency-halt.js
@@ -1,0 +1,302 @@
+/**
+ * GLOBAL EMERGENCY HALT — the agent-side half of SPRINT_BACKLOG L0 gate 0.4.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM `agent-controls.js` (checked first — they are
+ * NOT the same lever, and this does not replace it):
+ *   `agent-controls.js` reads `agent_controls.enabled` PER AGENT. It is the
+ *   right tool for "idle mel while I look at something". It is the wrong tool
+ *   for an emergency, for two measured reasons:
+ *     1. `agent_controls` currently holds THREE rows — mel, sophia, veritas
+ *        [sql:2026-07-27] — and `readEnabledFromDb` returns TRUE when no row
+ *        exists. Nine of the twelve production agents therefore cannot be
+ *        stopped by that lever at all until someone INSERTs a row first, which
+ *        is not something an operator discovers mid-incident.
+ *     2. Even fully populated it is twelve flips, not one, and it says nothing
+ *        about the non-agent producers in this repo (the seeding loop).
+ *   This module is the orthogonal axis: ONE boolean, EVERY acting loop. The two
+ *   compose — either can park an agent — and neither reads the other's storage.
+ *
+ * WHAT: `trinity_system_config.emergency_halt` (singleton row id=1) — the SAME
+ * column the repid-engine kill switch reads, so one flip stops the engine's
+ * workers, the engine's mutating HTTP surface, AND the twelve Railway agents.
+ * The column already exists in production [sql:2026-07-27]; this ships NO DDL.
+ *
+ * ── WHICH LOOPS ARE COVERED — ENUMERATED, NOT IMPLIED ────────────────────────
+ * The engine's first version of this switch claimed "worker tick loops park"
+ * and reached 3 of 14. The scope below was produced by grepping every
+ * `while (true)` and `setInterval(` in this repo (excluding node_modules and
+ * tests) and classifying each one, and `tests/emergency-halt-coverage.test.js`
+ * pins it against the filesystem so a NEW loop added later fails CI until it is
+ * covered or explicitly exempted here.
+ *
+ * COVERED (call `shouldParkForHalt()` before doing any work):
+ *   - lib/ConstitutionalAgentV4.js  `runLoop()`        — the 12 Railway agents
+ *   - lib/ConstitutionalAgentV4.js  `runLoopLegacy()`  — ditto (11 of 12 run this)
+ *   - constitutional-agent-base.js  main `while (true)` claim loop
+ *   - constitutional-agent-base.js  `runSelfDiagnostic()`  (it can trigger a
+ *     HEALING CASCADE and writes a genome report — that is the machine acting)
+ *   - constitutional-agent-base.js  `askEternalQuestions()`
+ *   - trinity-worker.js             `startSeedingLoop()` — a PRODUCER: it shells
+ *     out to seed evergreen tasks when agents look idle. A kill switch that does
+ *     not stop the thing that CREATES work is not a kill switch.
+ *
+ * DELIBERATELY EXEMPT, each for a stated reason (NOT an oversight):
+ *   - the `heartbeat()` setIntervals (ConstitutionalAgentV4, base, ConstitutionalAgent.ts)
+ *     — observability. A halt must stop the machine ACTING, not stop it
+ *     REPORTING; the operator needs /health and last_ping to watch the fleet
+ *     come to rest. Same call the engine made for `providers/health.ts`.
+ *   - mutual-wake.js — `fetch(agent.url + '/health')` only; enumerated for
+ *     writes and there are none. Read-only liveness pings.
+ *
+ * NOT WIRED BECAUSE THEY DO NOT RUN — evidence, not assumption:
+ *   - trinity.hdm.js       — calls `pollAndExecute` which is defined ZERO times
+ *                            in the file (9 lines total); it would throw at boot.
+ *   - trinity-{apm,orch,sophia,hdm,...}.js — one-line shims that spawn
+ *                            `scripts/run-agent.js`, which does not exist.
+ *   - w3c.index.js         — a full standalone agent loop, referenced by no file
+ *                            and no deploy config in this repo.
+ *   - lib/ConstitutionalAgent.ts — no `require`/`import` of it anywhere.
+ *   The live entry point is `server.js` (`npm start`) -> ConstitutionalAgentV4.
+ *   If any of these is ever revived it must be gated; the coverage test will
+ *   say so, because it classifies by filename and these are listed as dead.
+ *
+ * DEFAULT BEHAVIOUR IS UNCHANGED. The column defaults to false, so with nothing
+ * flipped every caller behaves exactly as it did before.
+ *
+ * MODE: EMERGENCY_HALT_MODE = enforce (DEFAULT) | shadow | off
+ *   enforce — flag true actually parks callers. Default ON PURPOSE: a kill
+ *             switch that ALSO needs an env var set is not a kill switch, it is
+ *             two levers, and the second one needs a redeploy of 12 services.
+ *   shadow  — read + log what WOULD park, change nothing.
+ *   off     — skip the check entirely, no DB read (escape hatch if this module
+ *             itself misbehaves).
+ * The parser FAILS CLOSED — the inverse of every other mode parser in the
+ * ecosystem, deliberately. Only `off` and `shadow` weaken the switch
+ * (case-insensitive, surrounding whitespace ignored, matching
+ * `toControlName`'s trim because a Railway field with a trailing space is a typo
+ * in the fingers, not the intent). `of`, `false`, `0`, `disabled`, garbage — all
+ * resolve to `enforce` and warn once. Other flags guard features that do damage
+ * when ON; this one guards the lever that STOPS damage. You cannot typo the kill
+ * switch into being disabled.
+ *
+ * FAILURE SEMANTICS (the part that matters — mirrors the engine exactly so an
+ * operator has ONE mental model across both repos):
+ *   - A read error can never START a halt. A flaky pooler must not park the fleet.
+ *   - A read error can never LIFT one. Once a successful read has seen true,
+ *     later failures keep the halt ("sticky"); only a successful read of FALSE
+ *     resumes. An operator who pulls the switch during an incident must not have
+ *     it released BY the incident.
+ *   - A MISSING COLUMN/TABLE is treated as "not halted" and warned once, so this
+ *     code is safe to run before, without, or after a rollback of the DDL.
+ * Note this is fail-OPEN while `agent-controls.js` is fail-CLOSED (default-off
+ * when unreachable). That is not an inconsistency: agent-controls already parks
+ * the agent when the store is unreachable, so nothing is lost, and making BOTH
+ * fail closed would mean a flaky read could park the fleet twice over with a
+ * misleading "EMERGENCY HALT" in the log.
+ *
+ * NO REDIS ON PURPOSE. `agent-controls.js` caches through Upstash; this does
+ * not. The switch has to work when infrastructure is misbehaving, and every
+ * extra hop is another place a stale `false` can survive. Cost of that choice,
+ * stated: one extra bounded query per agent per cache window — with 12 agents,
+ * a 30 s loop sleep and a 5 s cache that is ~0.4 reads/sec against the pooler.
+ *
+ * LEVERS: EMERGENCY_HALT_MODE · EMERGENCY_HALT_CACHE_MS (default 5000)
+ *       · EMERGENCY_HALT_TIMEOUT_MS (default 2000 — hard ceiling on how long
+ *         this check may block a tick; an overrun is treated as a failed read)
+ *
+ * OPERATOR RUNBOOK — one statement each way, from the Supabase SQL editor:
+ *
+ *   -- PULL THE SWITCH
+ *   UPDATE trinity_system_config
+ *      SET emergency_halt = true, emergency_halt_reason = '<why>',
+ *          emergency_halt_at = now(), emergency_halt_by = '<who>'
+ *    WHERE id = 1;
+ *
+ *   -- RESUME
+ *   UPDATE trinity_system_config
+ *      SET emergency_halt = false, emergency_halt_at = now(), emergency_halt_by = '<who>'
+ *    WHERE id = 1;
+ *
+ * Takes effect within EMERGENCY_HALT_CACHE_MS plus the caller's poll interval
+ * (worst case ~35 s on an idle agent, which sleeps 30 s between iterations).
+ */
+'use strict';
+
+const { pgQuery } = require('./direct-pg');
+
+const CACHE_MS = Number(process.env.EMERGENCY_HALT_CACHE_MS || 5000);
+const TIMEOUT_MS = Number(process.env.EMERGENCY_HALT_TIMEOUT_MS || 2000);
+
+const HALT_SQL = 'SELECT emergency_halt FROM trinity_system_config WHERE id = 1';
+
+/** Injection seam for tests — production always uses direct-pg's pgQuery. */
+let queryImpl = null;
+
+/** null = never successfully read. true/false = last SUCCESSFUL read (sticky). */
+let lastKnownHalt = null;
+let cacheExpiresAt = 0;
+let warnedUnknownMode = false;
+let warnedMissingColumn = false;
+
+/**
+ * Fail-closed mode parser. ONLY exact `off`/`shadow` (case/whitespace
+ * insensitive) weaken the switch; everything else is `enforce`.
+ * @param {unknown} raw
+ * @returns {'off'|'shadow'|'enforce'}
+ */
+function parseHaltMode(raw) {
+  if (typeof raw !== 'string') return 'enforce';
+  const v = raw.trim().toLowerCase();
+  if (v === 'off') return 'off';
+  if (v === 'shadow') return 'shadow';
+  if (v !== '' && v !== 'enforce' && !warnedUnknownMode) {
+    warnedUnknownMode = true;
+    console.warn(
+      `[emergency-halt] EMERGENCY_HALT_MODE="${raw}" is not off|shadow|enforce — ` +
+        'resolving to ENFORCE (this parser fails closed on purpose).'
+    );
+  }
+  return 'enforce';
+}
+
+function currentMode() {
+  return parseHaltMode(process.env.EMERGENCY_HALT_MODE);
+}
+
+/**
+ * A halt value must be unambiguously true. Accepts boolean true and the string
+ * 'true' (pg returns a boolean, but a JSON/REST path could hand back a string)
+ * and NOTHING else — so a stray value cannot park the fleet, while the one
+ * direction that matters (an operator pulled the switch) cannot be missed.
+ */
+function isHaltTruthy(v) {
+  return v === true || (typeof v === 'string' && v.trim().toLowerCase() === 'true');
+}
+
+function looksLikeMissingColumn(err) {
+  const msg = String((err && err.message) || err || '').toLowerCase();
+  return (
+    (err && err.code === '42703') ||
+    (err && err.code === '42P01') ||
+    (msg.includes('column') && msg.includes('does not exist')) ||
+    (msg.includes('relation') && msg.includes('does not exist'))
+  );
+}
+
+/** Bound the read. `pgQuery` races its own timeout, but this check must never
+ *  be able to wedge the loop it protects, so the ceiling is enforced here too.
+ *  The timer is NOT unref'd: it lives <= TIMEOUT_MS, and an unref'd timer can
+ *  let a short-lived process exit mid-await instead of failing open. */
+function withHardTimeout(promise, ms, label) {
+  let handle = null;
+  const timer = new Promise((_, reject) => {
+    handle = setTimeout(() => {
+      const e = new Error(`Timeout after ${ms}ms: ${label}`);
+      e.name = 'TimeoutError';
+      reject(e);
+    }, ms);
+  });
+  return Promise.race([promise, timer]).finally(() => {
+    if (handle) clearTimeout(handle);
+  });
+}
+
+/**
+ * Read the global halt flag. Cached for CACHE_MS. Never throws.
+ * @returns {Promise<{halted: boolean, source: string}>}
+ */
+async function readHalt() {
+  if (Date.now() < cacheExpiresAt && lastKnownHalt !== null) {
+    return { halted: lastKnownHalt, source: 'cache' };
+  }
+
+  const q = queryImpl || pgQuery;
+  try {
+    const rows = await withHardTimeout(
+      q(HALT_SQL, [], { retries: 1, timeoutMs: TIMEOUT_MS, label: 'emergency-halt-read' }),
+      TIMEOUT_MS,
+      'emergency-halt-read'
+    );
+    // No row at all is not a halt: the singleton is missing, not set.
+    const value = Array.isArray(rows) && rows.length ? rows[0].emergency_halt : false;
+    lastKnownHalt = isHaltTruthy(value);
+    cacheExpiresAt = Date.now() + CACHE_MS;
+    return { halted: lastKnownHalt, source: 'db' };
+  } catch (err) {
+    if (looksLikeMissingColumn(err)) {
+      if (!warnedMissingColumn) {
+        warnedMissingColumn = true;
+        console.warn(
+          '[emergency-halt] trinity_system_config.emergency_halt is absent — ' +
+            'treating as NOT halted (safe to run before/without the DDL).'
+        );
+      }
+      lastKnownHalt = false;
+      cacheExpiresAt = Date.now() + CACHE_MS;
+      return { halted: false, source: 'missing_column' };
+    }
+    // A failure can neither START a halt nor LIFT one.
+    if (lastKnownHalt === true) {
+      console.warn(
+        `[emergency-halt] read failed (${(err && err.message) || err}) — HALT STAYS IN PLACE (sticky).`
+      );
+      return { halted: true, source: 'error_sticky' };
+    }
+    console.warn(
+      `[emergency-halt] read failed (${(err && err.message) || err}) — failing open (not halted).`
+    );
+    return { halted: false, source: 'error_open' };
+  }
+}
+
+/**
+ * THE call site helper. `true` => the caller must park (claim nothing, spawn
+ * nothing, act on nothing) and try again on its next tick.
+ * @param {string} [who] label for the log line (agent name / loop name)
+ * @returns {Promise<boolean>}
+ */
+async function shouldParkForHalt(who = 'agent') {
+  const mode = currentMode();
+  if (mode === 'off') return false;
+
+  const { halted, source } = await readHalt();
+  if (!halted) return false;
+
+  if (mode === 'shadow') {
+    console.warn(`[emergency-halt] SHADOW: ${who} WOULD park (source=${source}); continuing.`);
+    return false;
+  }
+  console.warn(`[emergency-halt] 🛑 EMERGENCY HALT ACTIVE — ${who} is parking (source=${source}).`);
+  return true;
+}
+
+/** Drop the cache so the next read hits the DB (used after an external flip). */
+function bustHaltCache() {
+  cacheExpiresAt = 0;
+}
+
+/** Test seam — never called in production paths. */
+function __setQueryImplForTests(fn) {
+  queryImpl = fn;
+}
+
+/** Test seam — resets every module-level bit of state. */
+function __resetForTests() {
+  queryImpl = null;
+  lastKnownHalt = null;
+  cacheExpiresAt = 0;
+  warnedUnknownMode = false;
+  warnedMissingColumn = false;
+}
+
+module.exports = {
+  parseHaltMode,
+  isHaltTruthy,
+  readHalt,
+  shouldParkForHalt,
+  bustHaltCache,
+  CACHE_MS,
+  TIMEOUT_MS,
+  __setQueryImplForTests,
+  __resetForTests,
+};

--- a/tests/emergency-halt-coverage.test.js
+++ b/tests/emergency-halt-coverage.test.js
@@ -1,0 +1,225 @@
+// node tests/emergency-halt-coverage.test.js
+//
+// COVERAGE PIN for the global kill switch (L0 gate 0.4).
+//
+// Why this file exists: the engine's version of this switch shipped claiming
+// "worker tick loops park" and reached 3 of 14 — including, uncovered, the
+// worker that writes ERC-8004 deltas on-chain every 60s. Scope that is ASSERTED
+// rather than ENUMERATED silently stops covering things as code is added.
+//
+// Why it is written THIS way: the first version of the engine's equivalent pin
+// PASSED under two mutations (delete the gate call; move the gate after the
+// breaker) because it substring-matched the module name against the whole file
+// — so the leftover `require(...)` line alone made a file read as "covered".
+// A test that asserts a property must be checked against the ABSENCE of that
+// property. Therefore, here:
+//   - require/import lines are STRIPPED before searching, so an import can
+//     never be mistaken for a call;
+//   - the expected number of CALL SITES is pinned per file, so deleting one of
+//     two gates fails even though the other still matches;
+//   - ordering is asserted against the line the gate must precede, not against
+//     the import line (which is always first and therefore always "before").
+'use strict';
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const GATE = 'shouldParkForHalt';
+
+// ── The classification. Every loop-bearing file must appear in exactly one. ──
+
+/** Files that must CALL the gate, and how many distinct call sites each has. */
+const COVERED = {
+  'lib/ConstitutionalAgentV4.js': 2, // runLoop() + runLoopLegacy()
+  'constitutional-agent-base.js': 3, // main while(true) + self-diagnostic + eternal-questions
+  'trinity-worker.js': 1,            // the seeding PRODUCER
+};
+
+/** Loop-bearing files deliberately NOT gated, each with the reason. */
+const EXEMPT = {
+  'mutual-wake.js':
+    'health-ping only — enumerated for writes, there are none. Observability must survive a halt.',
+  'lib/ConstitutionalAgent.ts':
+    'legacy TS agent — required/imported by no file in this repo (dead).',
+  'w3c.index.js':
+    'standalone agent loop referenced by no file and no deploy config (dead).',
+  'trinity.hdm.js':
+    'calls pollAndExecute, which is defined ZERO times in the file — it throws at boot (dead).',
+};
+
+/** Loop constructs inside a covered file that are themselves exempt. */
+const INTERVAL_EXEMPTIONS = [
+  'heartbeat', // the 2-minute liveness setIntervals in V4 + base
+];
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+/** Strip require/import lines so an import can NEVER read as coverage. */
+function stripImports(src) {
+  return src
+    .split('\n')
+    .filter((l) => !/\b(require\s*\(|^\s*import\b)/.test(l))
+    .join('\n');
+}
+
+/** Count real call sites: `shouldParkForHalt(` with imports removed. */
+function countCallSites(src) {
+  const body = stripImports(src);
+  const m = body.match(new RegExp(GATE + '\\s*\\(', 'g'));
+  return m ? m.length : 0;
+}
+
+/**
+ * Strip comments before looking for loop constructs, so a file that merely
+ * DESCRIBES `setInterval(` in prose is not counted as having one. (Without
+ * this, lib/emergency-halt.js flags itself on its own header — the detector
+ * would be matching documentation instead of code.) `//` is ignored when
+ * preceded by `:` so a URL does not truncate the rest of the line.
+ */
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((l) => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .join('\n');
+}
+
+/** Every non-test, non-node_modules file containing a loop construct. */
+function enumerateLoopFiles() {
+  const found = [];
+  const skipDirs = new Set(['node_modules', '.git', 'tests', 'generated', 'docs', 'reports']);
+  (function walk(dir, rel) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      const r = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (!skipDirs.has(entry.name) && !entry.name.startsWith('.')) walk(abs, r);
+        continue;
+      }
+      if (!/\.(js|ts)$/.test(entry.name)) continue;
+      if (/\.test\.(js|ts)$/.test(entry.name)) continue;
+      let src;
+      try { src = fs.readFileSync(abs, 'utf8'); } catch (_) { continue; }
+      if (/while\s*\(\s*true\s*\)|setInterval\s*\(/.test(stripComments(src))) found.push(r);
+    }
+  })(ROOT, '');
+  return found.sort();
+}
+
+// ── 1. Every covered file calls the gate the pinned number of times ──────────
+for (const [rel, expected] of Object.entries(COVERED)) {
+  const src = read(rel);
+  const n = countCallSites(src);
+  assert.strictEqual(
+    n, expected,
+    `${rel}: expected ${expected} ${GATE}() call site(s), found ${n}. ` +
+      'If you added or removed a loop, update COVERED here and say why in the module header.'
+  );
+  // An import alone must never satisfy the pin — prove the strip works on the
+  // real file rather than trusting it.
+  assert.ok(
+    /require\([^)]*emergency-halt/.test(src),
+    `${rel}: expected an emergency-halt require (the pin strips it before counting)`
+  );
+}
+console.log(`  ok  ${Object.keys(COVERED).length} covered files call ${GATE}() the pinned number of times`);
+
+// ── 2. Ordering: the halt gate precedes the per-agent gate in BOTH V4 loops ──
+// A global stop that runs after a per-agent check can be masked by that check's
+// behaviour, and the log line would name the wrong cause.
+{
+  const src = read('lib/ConstitutionalAgentV4.js');
+  const body = stripImports(src);
+  const lines = body.split('\n');
+  const gateLines = [];
+  const workEnabledLines = [];
+  lines.forEach((l, i) => {
+    if (l.includes(GATE + '(')) gateLines.push(i);
+    if (l.includes('this.isWorkEnabled()')) workEnabledLines.push(i);
+  });
+  assert.strictEqual(gateLines.length, 2, `expected 2 halt gates in V4, got ${gateLines.length}`);
+  assert.strictEqual(workEnabledLines.length, 2, `expected 2 isWorkEnabled gates in V4, got ${workEnabledLines.length}`);
+  for (let i = 0; i < 2; i++) {
+    assert.ok(
+      gateLines[i] < workEnabledLines[i],
+      `V4 loop #${i + 1}: the halt gate (line ${gateLines[i] + 1}) must precede ` +
+        `isWorkEnabled (line ${workEnabledLines[i] + 1})`
+    );
+    // ...and must belong to the SAME loop, not be borrowed from the one above.
+    assert.ok(
+      workEnabledLines[i] - gateLines[i] < 15,
+      `V4 loop #${i + 1}: the halt gate is ${workEnabledLines[i] - gateLines[i]} lines ` +
+        'from its isWorkEnabled — that is too far to be the same guard block'
+    );
+  }
+}
+console.log('  ok  in both V4 loops the halt gate precedes the per-agent gate, in the same block');
+
+// ── 3. The seeder gate is the FIRST thing in its interval body ──────────────
+// A producer that checks the switch after doing its work has already acted.
+{
+  const body = stripImports(read('trinity-worker.js'));
+  const idx = body.indexOf('startSeedingLoop');
+  assert.ok(idx > 0, 'startSeedingLoop not found');
+  const after = body.slice(idx);
+  const gateAt = after.indexOf(GATE + '(');
+  const workAt = after.indexOf('trinity_agent_registry');
+  assert.ok(gateAt > 0, 'seeding loop is not gated');
+  assert.ok(workAt > 0, 'seeding loop no longer reads trinity_agent_registry — re-check this pin');
+  assert.ok(gateAt < workAt, 'the seeder must check the halt BEFORE it counts idle agents');
+}
+console.log('  ok  the seeding producer checks the halt before it does anything');
+
+// ── 4. Nothing is unclassified — a NEW loop file fails until it is triaged ──
+{
+  const loopFiles = enumerateLoopFiles();
+  const classified = new Set([...Object.keys(COVERED), ...Object.keys(EXEMPT)]);
+  const unclassified = loopFiles.filter((f) => !classified.has(f));
+  assert.deepStrictEqual(
+    unclassified, [],
+    'These files contain a loop but are neither COVERED nor EXEMPT in ' +
+      'tests/emergency-halt-coverage.test.js:\n  ' + unclassified.join('\n  ') +
+      '\nGate them with ' + GATE + '() or add an EXEMPT entry stating why.'
+  );
+  // The classification must not rot in the other direction either: a file
+  // listed here that no longer has a loop is a stale claim.
+  const enumerated = new Set(loopFiles);
+  for (const rel of classified) {
+    assert.ok(enumerated.has(rel), `${rel} is classified but no longer contains a loop — remove it`);
+  }
+  console.log(`  ok  all ${loopFiles.length} loop-bearing files classified (${Object.keys(COVERED).length} covered, ${Object.keys(EXEMPT).length} exempt)`);
+}
+
+// ── 5. Every exemption states a reason (not just a filename) ────────────────
+for (const [rel, why] of Object.entries(EXEMPT)) {
+  assert.ok(why && why.length > 30, `${rel}: exemption reason is too thin to be a decision`);
+}
+console.log(`  ok  all ${Object.keys(EXEMPT).length} exemptions carry a stated reason`);
+
+// ── 6. The dead-file claims are still true ─────────────────────────────────
+// These exemptions rest on facts about the repo, not opinions. If someone
+// revives one of them, the exemption is no longer valid and must be re-decided.
+{
+  const hdm = read('trinity.hdm.js');
+  assert.ok(
+    /pollAndExecute/.test(hdm) && !/function\s+pollAndExecute|pollAndExecute\s*=/.test(hdm),
+    'trinity.hdm.js now defines pollAndExecute — it is no longer dead, so gate it'
+  );
+  assert.ok(
+    !fs.existsSync(path.join(ROOT, 'scripts/run-agent.js')),
+    'scripts/run-agent.js now exists — the trinity-*.js shims may be live again; re-check coverage'
+  );
+  for (const dead of ['w3c.index.js', 'lib/ConstitutionalAgent.ts']) {
+    const base = path.basename(dead).replace(/\.(js|ts)$/, '');
+    const referenced = enumerateLoopFiles()
+      .filter((f) => f !== dead)
+      .some((f) => new RegExp(`require\\([^)]*${base.replace('.', '\\.')}`).test(read(f)));
+    assert.ok(!referenced, `${dead} is now required by a live loop file — it is not dead; gate it`);
+  }
+}
+console.log('  ok  the "dead file" exemptions are still factually true');
+
+console.log('emergency-halt-coverage.test.js: OK');

--- a/tests/emergency-halt.test.js
+++ b/tests/emergency-halt.test.js
@@ -1,0 +1,218 @@
+// node tests/emergency-halt.test.js
+//
+// Behaviour pins for the agent-side global kill switch (L0 gate 0.4).
+// Plain-node + assert, matching this repo's existing test convention.
+//
+// The properties asserted here are the ones that decide whether the switch is
+// trustworthy in an incident, not merely present:
+//   - it cannot be typo'd into being disabled (fail-closed mode parser)
+//   - a flaky database can neither START a halt nor LIFT one
+//   - a missing column is inert (safe to deploy before/without the DDL)
+//   - the read is BOUNDED (a hung DB must not wedge the loop it protects)
+//   - shadow mode does not park, and says so honestly
+'use strict';
+const assert = require('assert');
+
+const halt = require('../lib/emergency-halt');
+const { parseHaltMode, isHaltTruthy, readHalt, shouldParkForHalt } = halt;
+
+/** A fake pgQuery. `behaviour` decides what the read does. */
+function fakeQuery(behaviour) {
+  const state = { calls: 0 };
+  const fn = async () => {
+    state.calls++;
+    return behaviour(state.calls);
+  };
+  fn.state = state;
+  return fn;
+}
+
+function reset(mode) {
+  halt.__resetForTests();
+  if (mode === undefined) delete process.env.EMERGENCY_HALT_MODE;
+  else process.env.EMERGENCY_HALT_MODE = mode;
+}
+
+async function main() {
+  // ── 1. MODE PARSER FAILS CLOSED ────────────────────────────────────────────
+  // Only exact off/shadow (case + surrounding whitespace insensitive) weaken it.
+  // NOTE: these are ALL legitimate case/whitespace variants of exactly "off".
+  // `ofF ` and `off\n` belong here, not in the enforce list — a Railway field
+  // with a trailing newline is a typo in the fingers, not in the intent. (My
+  // first version of this test asserted the opposite and the run corrected me.)
+  for (const v of ['off', 'OFF', ' off ', 'Off', 'ofF ', ' off', 'off\n', '\toff\t']) {
+    assert.strictEqual(parseHaltMode(v), 'off', `expected off for ${JSON.stringify(v)}`);
+  }
+  for (const v of ['shadow', 'SHADOW', '  Shadow\t']) {
+    assert.strictEqual(parseHaltMode(v), 'shadow', `expected shadow for ${JSON.stringify(v)}`);
+  }
+  // Everything else must resolve to enforce. These are the values an operator
+  // or a bad deploy actually produces — each one, misparsed, silently disables
+  // the kill switch.
+  const mustEnforce = [
+    'of', 'false', 'FALSE', '0', '1', 'disabled', 'disable', 'no', 'none',
+    'null', 'undefined', '', '   ', 'enforce', 'ENFORCE', 'enforce ', 'shadowy',
+    'offf', 'o ff', 'off;', 'shadow-mode', 'true', 'yes', 'halt', 'off off',
+    '\u0000off', 'o​ff', 'ｏｆｆ', 'öff', 'off,shadow', 'sh adow', 'SHADOW!', '-off', 'off=1', 'off .', '["off"]', '{"mode":"off"}',
+  ];
+  for (const v of mustEnforce) {
+    assert.strictEqual(parseHaltMode(v), 'enforce', `expected enforce for ${JSON.stringify(v)}`);
+  }
+  // Non-strings can never weaken it either.
+  for (const v of [undefined, null, 0, 1, false, true, {}, [], ['off'], { toString: () => 'off' }]) {
+    assert.strictEqual(parseHaltMode(v), 'enforce', `expected enforce for ${String(v)}`);
+  }
+  console.log(`  ok  mode parser fails closed (${8 + 3 + mustEnforce.length + 10} values)`);
+
+  // ── 2. TRUTHINESS IS NARROW IN ONE DIRECTION ONLY ─────────────────────────
+  for (const v of [true, 'true', 'TRUE', ' true ']) {
+    assert.strictEqual(isHaltTruthy(v), true, `expected halt-truthy: ${String(v)}`);
+  }
+  for (const v of [false, 'false', 't', 1, '1', 'yes', null, undefined, [], {}, 'True!']) {
+    assert.strictEqual(isHaltTruthy(v), false, `expected NOT halt-truthy: ${String(v)}`);
+  }
+  console.log('  ok  isHaltTruthy accepts true/"true" and nothing else');
+
+  // ── 3. THE HAPPY PATHS ─────────────────────────────────────────────────────
+  reset('enforce');
+  halt.__setQueryImplForTests(fakeQuery(() => [{ emergency_halt: false }]));
+  assert.deepStrictEqual(await readHalt(), { halted: false, source: 'db' });
+  assert.strictEqual(await shouldParkForHalt('t'), false);
+
+  reset('enforce');
+  halt.__setQueryImplForTests(fakeQuery(() => [{ emergency_halt: true }]));
+  assert.deepStrictEqual(await readHalt(), { halted: true, source: 'db' });
+  assert.strictEqual(await shouldParkForHalt('t'), true);
+  console.log('  ok  false => run, true => park');
+
+  // A missing singleton row is NOT a halt (config absent, not set).
+  reset('enforce');
+  halt.__setQueryImplForTests(fakeQuery(() => []));
+  assert.strictEqual((await readHalt()).halted, false);
+  console.log('  ok  no row => not halted');
+
+  // ── 4. A READ ERROR CAN NEVER *START* A HALT ──────────────────────────────
+  reset('enforce');
+  halt.__setQueryImplForTests(fakeQuery(() => { throw new Error('pooler unreachable'); }));
+  const openRes = await readHalt();
+  assert.strictEqual(openRes.halted, false);
+  assert.strictEqual(openRes.source, 'error_open');
+  assert.strictEqual(await shouldParkForHalt('t'), false);
+  console.log('  ok  read error fails OPEN (a flaky DB cannot park the fleet)');
+
+  // ── 5. A READ ERROR CAN NEVER *LIFT* A HALT (sticky) ──────────────────────
+  // This is the one that matters most: an operator pulls the switch DURING an
+  // incident; the incident must not release it.
+  reset('enforce');
+  halt.__setQueryImplForTests(fakeQuery((n) => {
+    if (n === 1) return [{ emergency_halt: true }];
+    throw new Error('pooler died right after');
+  }));
+  assert.strictEqual((await readHalt()).halted, true, 'first read should halt');
+  halt.bustHaltCache();
+  const sticky = await readHalt();
+  assert.strictEqual(sticky.halted, true, 'halt must survive a failed read');
+  assert.strictEqual(sticky.source, 'error_sticky');
+  console.log('  ok  halt is STICKY across read failures');
+
+  // ...and only a successful read of FALSE resumes.
+  reset('enforce');
+  let phase = 'halt';
+  halt.__setQueryImplForTests(fakeQuery(() => {
+    if (phase === 'halt') return [{ emergency_halt: true }];
+    if (phase === 'error') throw new Error('flaky');
+    return [{ emergency_halt: false }];
+  }));
+  assert.strictEqual((await readHalt()).halted, true);
+  phase = 'error'; halt.bustHaltCache();
+  assert.strictEqual((await readHalt()).halted, true);
+  phase = 'ok'; halt.bustHaltCache();
+  assert.strictEqual((await readHalt()).halted, false, 'a successful false must resume');
+  console.log('  ok  only a successful read of false resumes');
+
+  // ── 6. MISSING COLUMN IS INERT ────────────────────────────────────────────
+  for (const err of [
+    Object.assign(new Error('boom'), { code: '42703' }),
+    Object.assign(new Error('boom'), { code: '42P01' }),
+    new Error('column "emergency_halt" does not exist'),
+    new Error('relation "trinity_system_config" does not exist'),
+  ]) {
+    reset('enforce');
+    halt.__setQueryImplForTests(fakeQuery(() => { throw err; }));
+    const r = await readHalt();
+    assert.strictEqual(r.halted, false);
+    assert.strictEqual(r.source, 'missing_column', `expected missing_column for ${err.code || err.message}`);
+  }
+  console.log('  ok  missing column/table => inert (safe before/without the DDL)');
+
+  // ── 7. THE READ IS BOUNDED ────────────────────────────────────────────────
+  // A hung database must not wedge the loop this switch protects. The engine
+  // shipped exactly this bug and only CI caught it.
+  //
+  // THE WATCHDOG IS NOT DECORATION — it is the only reason this check can fail.
+  // The first version of this test just awaited readHalt() and measured the
+  // elapsed time. A mutation that DELETED the timeout made it pass anyway:
+  // with the fake query never settling and nothing else on the event loop,
+  // Node judged the loop empty and exited 0 *inside the await*, so the
+  // assertions never ran and the suite "passed". That is Beat 34's
+  // exit-mid-await defect reproduced in a test instead of a script. The
+  // watchdog's timer keeps the loop alive AND rejects, so an unbounded read
+  // now fails loudly instead of vanishing.
+  reset('enforce');
+  halt.__setQueryImplForTests(() => new Promise(() => {})); // never settles
+  const ceiling = halt.TIMEOUT_MS + 1500;
+  const t0 = Date.now();
+  let watchdogTimer = null;
+  const watchdog = new Promise((_, reject) => {
+    watchdogTimer = setTimeout(
+      () => reject(new Error(`readHalt() did not return within ${ceiling}ms — the read is NOT bounded`)),
+      ceiling
+    );
+  });
+  let hung;
+  try {
+    hung = await Promise.race([readHalt(), watchdog]);
+  } finally {
+    clearTimeout(watchdogTimer);
+  }
+  const elapsed = Date.now() - t0;
+  assert.strictEqual(hung.halted, false, 'a hung read must fail open, not hang');
+  assert.ok(elapsed < ceiling, `read took ${elapsed}ms, expected < ${ceiling}ms`);
+  console.log(`  ok  hung read bounded at ${elapsed}ms (ceiling ${halt.TIMEOUT_MS}ms) and fails open`);
+
+  // ── 8. SHADOW DOES NOT PARK; OFF DOES NOT EVEN READ ───────────────────────
+  reset('shadow');
+  const shadowQ = fakeQuery(() => [{ emergency_halt: true }]);
+  halt.__setQueryImplForTests(shadowQ);
+  assert.strictEqual(await shouldParkForHalt('t'), false, 'shadow must not park');
+  assert.ok(shadowQ.state.calls > 0, 'shadow must still READ (that is the point of shadow)');
+
+  reset('off');
+  const offQ = fakeQuery(() => [{ emergency_halt: true }]);
+  halt.__setQueryImplForTests(offQ);
+  assert.strictEqual(await shouldParkForHalt('t'), false, 'off must not park');
+  assert.strictEqual(offQ.state.calls, 0, 'off must not even query');
+  console.log('  ok  shadow reads-but-does-not-park; off does not read at all');
+
+  // ── 9. THE CACHE ACTUALLY CACHES (and busts) ──────────────────────────────
+  reset('enforce');
+  const cq = fakeQuery(() => [{ emergency_halt: false }]);
+  halt.__setQueryImplForTests(cq);
+  await readHalt(); await readHalt(); await readHalt();
+  assert.strictEqual(cq.state.calls, 1, `expected 1 db call, got ${cq.state.calls}`);
+  assert.strictEqual((await readHalt()).source, 'cache');
+  halt.bustHaltCache();
+  await readHalt();
+  assert.strictEqual(cq.state.calls, 2, 'bustHaltCache must force a fresh read');
+  console.log('  ok  cache holds within the window and busts on demand');
+
+  reset(undefined);
+  halt.__resetForTests();
+}
+
+main().then(() => {
+  console.log('emergency-halt.test.js: OK');
+}).catch((e) => {
+  console.error('emergency-halt.test.js: FAILED —', e && e.stack ? e.stack : e);
+  process.exit(1);
+});

--- a/trinity-worker.js
+++ b/trinity-worker.js
@@ -24,6 +24,7 @@ const fs = require('fs').promises;
 const path = require('path');
 const { checkAndApplyUpdates } = require('./auto_updater');
 const { startMutualWakeLoop } = require('./mutual-wake');
+const { shouldParkForHalt } = require('./lib/emergency-halt'); // L0 gate 0.4 — GLOBAL kill switch
 const analyzeRoutes = require('./routes/analyze');
 
 (async () => {
@@ -274,6 +275,11 @@ async function startSeedingLoop(agent) {
 
   setInterval(async () => {
     try {
+      // L0 gate 0.4 — GLOBAL emergency halt, checked FIRST. This loop is a
+      // PRODUCER: past the threshold it shells out and seeds evergreen tasks.
+      // A kill switch that stops the consumers but leaves the thing that
+      // CREATES work running just refills the queue it was meant to drain.
+      if (await shouldParkForHalt('trinity-worker:seeder')) return;
       // 1. Load Arbitrage Config for thresholds
       const configPath = path.resolve(__dirname, './config/trinity-arbitrage-config.json');
       const configRaw = await fs.readFile(configPath, 'utf8').catch(() => null);


### PR DESCRIPTION
**The engine half of this kill switch is repid-engine #216. This is the other half.** The twelve Railway agents that actually claim and execute work live in this repo, and the switch did not exist here at all. Same column — `trinity_system_config.emergency_halt` — one flip, both halves. **Zero DDL:** the column already exists in production.

Backlog item **0.4**, an **L0 precondition** listed as gating *all autonomy gates*.

## Check-first: why the lever that already exists isn't enough

`lib/agent-controls.js` reads `agent_controls.enabled` per agent and is called once per loop iteration. It's the right tool for "idle mel while I look at something". It's the wrong tool for an emergency:

- **`agent_controls` holds three rows** — `mel`, `sophia`, `veritas` [V sql:2026-07-27] — and `readEnabledFromDb` returns **`true` when no row exists**. **Nine of the twelve agents cannot be stopped by it** until someone INSERTs a row first, which is not something an operator discovers mid-incident.
- Even fully populated it's twelve flips, not one, and says nothing about the producer in `trinity-worker.js`.

This **composes** with that lever rather than replacing it, and deliberately does **not** refactor it (CLAUDE-RULE-3) — the duplicated cache plumbing is named in the module header instead of being quietly resolved into a third convention.

## Scope is enumerated, not asserted

Every `while (true)` / `setInterval(` outside `node_modules`/`tests` classified — 7 loop-bearing files:

**COVERED (6 call sites / 3 files):** V4 `runLoop()` · V4 `runLoopLegacy()` (*11 of 12 agents run this one*) · `constitutional-agent-base.js` main loop (*it claims tasks and has **no** `agent_controls` gate of its own*) · `runSelfDiagnostic()` (*can trigger a healing cascade + writes a genome report*) · `askEternalQuestions()` · **`trinity-worker.js` seeding loop — a PRODUCER** that shells out to seed evergreen tasks. A switch that stops the consumers but leaves the thing that *creates* work running just refills the queue it was meant to drain.

**EXEMPT, with reasons:** the `heartbeat()` intervals (a halt must stop the machine **acting**, not **reporting** — the operator needs `/health` to watch the fleet come to rest) and `mutual-wake.js` (health `fetch` only; enumerated for writes, there are none).

**DEAD, with evidence:** `trinity.hdm.js` (calls `pollAndExecute`, defined **zero** times) · the `trinity-*.js` shims (spawn **`scripts/run-agent.js`, which does not exist**) · `w3c.index.js` (referenced by no file, no deploy config) · `lib/ConstitutionalAgent.ts` (imported by nothing). Live entry point is `server.js` → `ConstitutionalAgentV4`. **The coverage test asserts each dead-file claim is still true**, so reviving one fails CI instead of silently adding an ungated loop.

## Behaviour

Default is byte-identical — the column defaults to `false`.

- **`enforce` is the default and the mode parser fails CLOSED.** Only exact `off`/`shadow` weaken it; `of`/`false`/`0`/garbage → `enforce` + warn once. You cannot typo the kill switch into being disabled.
- **Gate precedes the per-agent gate** — a global stop that runs second can be masked by the first, and the log would name the wrong cause.
- **Parks via the existing `idleWhenDisabled()`** so liveness keeps reporting.
- **Fail-OPEN on a read error, STICKY once true.** A flaky pooler must not park the fleet; an operator who pulls the switch during an incident must not have it released *by* the incident. (Inverse of `agent-controls`, which is fail-closed — deliberate: that module already parks on an unreachable store, so nothing is lost and a DB blip doesn't print a misleading "EMERGENCY HALT".)
- **Missing column inert + warned once**; **read bounded** (2 s) and the timer is **not `unref`'d** (#216 shipped an unref'd timeout that let a process exit mid-`await`).
- **No Redis**, unlike `agent-controls`: the switch must work when infrastructure is misbehaving, and every hop is another place a stale `false` survives. Cost ≈ 0.4 reads/sec across all 12 agents.

## Verification

- **[V] 12/12 mutations killed**, measured against the final code, with both prior harness guards encoded: restore in a `finally`, and a marker asserted 0× before / 1× after or the result is **DISCARDED as NOT-LANDED**. Includes a **vacuity probe** (replace a gate with a comment that mentions it) and *a new unclassified loop file appears*.
- **[V] 7/7 node tests pass** · **[V] `node -c` clean** on all four touched source files · **[V] zero mutation residue on disk, checked not assumed.**
- **[V] Live before building:** the column exists as `boolean NOT NULL DEFAULT false` with 3 audit columns; flag currently `false`; `agent_controls` = 3 rows.
- **[V] Provably inert:** `origin/main` here has **zero** references to the flag, and the engine reports `deployed_commit=a1b6e7f`, which predates the column.

**One of those mutations found a defect in my own test.** The bounded-read pin PASSED with the bound removed: the fake query never settles, nothing else is on the event loop, so **Node exited 0 inside the `await`** and the assertions never ran — Beat 34's exit-mid-await defect reproduced in a test. Fixed with a watchdog that both keeps the loop alive and rejects.

## Two limits, stated

1. **No live true-state acceptance run.** The prod `UPDATE` was blocked by the session's permission classifier and I did not work around it. Unproven: only the observable *reaction* to a live flip.
2. **The real `pgQuery` path is exercised through an injected fake**, not the live pooler (no `DATABASE_URL` locally, and getting one means handling a plaintext secret). Residual risk is node-pg row mapping — mitigated by `agent-controls.js` running an identical `SELECT <bool> FROM <table> WHERE <pk>` in production today. **Re-check once on first deploy.**

Full write-up: `docs/BEAT36_AGENT_EMERGENCY_HALT.md`.

**Carried, not bundled:** this repo's `ci.yml` has the same `pull_request: branches: [main]` filter that repid-engine #213 removes, so stacked PRs here would run no checks. This PR is based on `main`, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
