### PR TITLE
fix(claim): durable re-claim cap — stop unbounded task cycling (435029: 365 claims / 239 artifacts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,14 @@ jobs:
         run: |
           node -c lib/ConstitutionalAgentV4.js
           node -c lib/tool-call-logger.js
+          node -c scripts/ops/claim-exhausted.js
           if [ -f lib/getNextTask.js ]; then node -c lib/getNextTask.js; fi
 
       - name: Node tests
         run: |
           node tests/getNextTask.test.js
           node tests/claimCap.test.js
+          node tests/claimCallSite.test.js
           node tests/provenance.test.js
           node tests/pulseCheckExecutor.test.js
           node tests/heartbeatDbWritesGate.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Node tests
         run: |
           node tests/getNextTask.test.js
+          node tests/claimCap.test.js
           node tests/provenance.test.js
           node tests/pulseCheckExecutor.test.js
           node tests/heartbeatDbWritesGate.test.js

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -1764,6 +1764,22 @@ CRITERIA: ${task.success_criteria}
         // status set incl. 'assigned', (c) the gated CAPABILITY_FILTER (default OFF => $5 NULL =>
         // task_type predicate is a no-op). trinity_tasks.id is BIGINT (CLAUDE-RULE-5) => blacklist
         // cast ::bigint[], NOT ::uuid[].
+        //
+        // DURABLE RE-CLAIM CAP (2026-07-27, CC autonomous loop Beat 42). The claim above is already
+        // race-safe, so the runaway measured on task 435029 was NOT a claim race: it was UNBOUNDED
+        // RE-CLAIM. Several paths legitimately return a task to a claimable status with
+        // claimed_by=NULL — releaseTask() -> 'pending' (understand-fail, capability-gap), the
+        // exception path -> 'pending', and the escalation path -> 'pending_clarification', which is
+        // itself in the claimable set. The ONLY brake was this.claimHistory, an IN-MEMORY Map, so it
+        // (a) is lost on restart, (b) is per-agent-process, so 11 agents each got their own budget,
+        // and (c) is not incremented on the escalation path at all. Net effect measured
+        // [V sql:2026-07-27]: task 435029 claimed 365x, 239 artifacts, 11 agents, ~1h40m, ~1 LLM call
+        // per 25s, terminating only by luck when a substance-gate event finally recorded.
+        // FIX: count claims DURABLY, in the claim statement itself, and refuse to serve a task past
+        // the cap. Counting at CLAIM time (not at release time) is what makes this total: it bounds
+        // every release path that exists today and every one added later, without enumerating them.
+        // NOTE: an exhausted task stays 'pending' but stops being served — it is parked, not lost,
+        // and the escalation/HITL rows that accompany these cycles are how a human finds it.
         const CAPABILITY_FILTER = process.env.CAPABILITY_FILTER === 'true';
         const HANDLED = (process.env.AGENT_TASK_TYPES ||
             'peer_verify,review,meta,system,research,code,docs,artifact,critique')
@@ -1777,21 +1793,8 @@ CRITERIA: ${task.success_criteria}
         let rows;
         try {
             rows = await pgQuery(
-                `UPDATE trinity_tasks
-                    SET status = 'doing', claimed_by = $1, claimed_at = $2, started_at = $2
-                  WHERE id = (
-                    SELECT id FROM trinity_tasks
-                     WHERE (assigned_to = $1 OR (assigned_to IS NULL AND (agent_assigned = $1 OR agent_assigned IS NULL)))
-                       AND status = ANY($3)
-                       AND claimed_by IS NULL
-                       AND ($5::text[] IS NULL OR task_type IS NULL OR task_type = ANY($5))
-                       AND NOT (id = ANY($4::bigint[]))
-                     ORDER BY priority DESC, created_at ASC
-                     LIMIT 1
-                     FOR UPDATE SKIP LOCKED
-                  )
-                  RETURNING id, title, description, metadata, priority, task_type, agent_assigned, status`,
-                [this.name, now, ['pending', 'todo', 'assigned', 'pending_clarification'], blacklist, capFilter],
+                ConstitutionalAgentV4.CLAIM_SQL,
+                ConstitutionalAgentV4.buildClaimParams(this.name, now, blacklist, capFilter),
                 { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'getNextTask(atomic-claim)' }
             );
         } catch (error) {
@@ -2772,6 +2775,73 @@ ConstitutionalAgentV4.DELIVERABLE_TASK_TYPES = new Set([
 ]);
 // Minimum result length (chars) that counts as "substantive" enough to auto-save.
 ConstitutionalAgentV4.MIN_ARTIFACT_CHARS = 40;
+// --- DURABLE RE-CLAIM CAP (2026-07-27, Beat 42) — see the long note in getNextTask() ---
+// The task statuses a task can be claimed FROM. 'pending_clarification' is in this set by design
+// (#25): an escalated task is re-offered to the pool. That is exactly why an unbounded cycle was
+// possible, and why the cap below has to be durable rather than in-memory.
+ConstitutionalAgentV4.CLAIMABLE_STATUSES = ['pending', 'todo', 'assigned', 'pending_clarification'];
+// How many times a single task may be claimed, ever, across all agents and restarts. Env-tunable
+// so it can be raised without a deploy. 12 = comfortably above any legitimate retry pattern
+// (MAX_CLAIM_RETRIES is 3, per agent) and far below the 365 observed on task 435029.
+ConstitutionalAgentV4.DEFAULT_MAX_TASK_CLAIMS = 12;
+ConstitutionalAgentV4.maxTaskClaims = function () {
+    const raw = Number.parseInt(process.env.MAX_TASK_CLAIMS || '', 10);
+    return Number.isFinite(raw) && raw > 0 ? raw : ConstitutionalAgentV4.DEFAULT_MAX_TASK_CLAIMS;
+};
+// The claim statement, hoisted so tests can assert on the guards the live query actually carries.
+// $6 = the cap. claim_count is incremented in the SAME statement that claims, so the count is
+// exact under concurrency for the same reason the claim itself is (single-row UPDATE ... WHERE id =
+// (SELECT ... FOR UPDATE SKIP LOCKED)) — no read-modify-write window.
+ConstitutionalAgentV4.CLAIM_SQL =
+    `UPDATE trinity_tasks
+        SET status = 'doing', claimed_by = $1, claimed_at = $2, started_at = $2,
+            claim_count = COALESCE(claim_count, 0) + 1
+      WHERE id = (
+        SELECT id FROM trinity_tasks
+         WHERE (assigned_to = $1 OR (assigned_to IS NULL AND (agent_assigned = $1 OR agent_assigned IS NULL)))
+           AND status = ANY($3)
+           AND claimed_by IS NULL
+           AND ($5::text[] IS NULL OR task_type IS NULL OR task_type = ANY($5))
+           AND NOT (id = ANY($4::bigint[]))
+           AND COALESCE(claim_count, 0) < $6
+         ORDER BY priority DESC, created_at ASC
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+      )
+      RETURNING id, title, description, metadata, priority, task_type, agent_assigned, status, claim_count`;
+// The bind list for CLAIM_SQL, hoisted for the same reason the SQL is. A missing bind is not a
+// soft failure: Postgres rejects the statement, getNextTask() catches and returns null, and every
+// agent goes quietly idle — an outage that looks exactly like an empty queue. The accompanying test
+// asserts this array's length against the highest $N placeholder in CLAIM_SQL, so the two cannot
+// drift out of step. (Found by mutation M12, which survived the first version of that test suite.)
+ConstitutionalAgentV4.buildClaimParams = function (agentName, now, blacklist, capFilter) {
+    return [agentName, now, ConstitutionalAgentV4.CLAIMABLE_STATUSES, blacklist, capFilter,
+        ConstitutionalAgentV4.maxTaskClaims()];
+};
+// Pure mirror of CLAIM_SQL's selector, for tests that need to exercise the CYCLE rather than the
+// string. It is deliberately a mirror and not the source of truth: the accompanying test asserts
+// that CLAIM_SQL still carries each guard this function implements, so the two cannot drift apart
+// silently (a mirror that moved with the implementation would prove nothing).
+ConstitutionalAgentV4.selectClaimableTask = function (tasks, opts) {
+    const { agentName, blacklist = [], maxClaims = ConstitutionalAgentV4.maxTaskClaims(), taskTypes = null } = opts || {};
+    const black = new Set(blacklist);
+    const claimable = ConstitutionalAgentV4.CLAIMABLE_STATUSES;
+    const candidates = (tasks || []).filter((t) =>
+        (t.assigned_to === agentName || (t.assigned_to == null && (t.agent_assigned === agentName || t.agent_assigned == null)))
+        && claimable.includes(t.status)
+        && t.claimed_by == null
+        && (taskTypes == null || t.task_type == null || taskTypes.includes(t.task_type))
+        && !black.has(t.id)
+        && (t.claim_count || 0) < maxClaims);
+    candidates.sort((a, b) => (b.priority || 0) - (a.priority || 0)
+        || String(a.created_at || '').localeCompare(String(b.created_at || '')));
+    const picked = candidates[0];
+    if (!picked) return null;
+    picked.status = 'doing';
+    picked.claimed_by = agentName;
+    picked.claim_count = (picked.claim_count || 0) + 1;
+    return picked;
+};
 // Pure predicate: is this a deliverable task that requires an artifact?
 ConstitutionalAgentV4.isDeliverableTask = function (task) {
     if (!task) return false;

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -721,27 +721,41 @@ class ConstitutionalAgentV4 {
                 updatedMetadata.reap_count = (updatedMetadata.reap_count || 0) + 1;
                 updatedMetadata.last_reaped_at = new Date().toISOString();
 
-                const { error: updateError } = await this.supabase
-                    .from('trinity_tasks')
-                    .update({
-                        status: 'pending',
-                        claimed_by: null,
-                        claimed_at: null,
-                        metadata: updatedMetadata
-                    })
-                    .eq('id', task.id)
-                    .in('status', ['doing', 'in_progress']); // Re-check at update to avoid race
-
-                if (updateError) {
+                // CLAIM REFUND (2026-07-27, Beat 44 — verifier findings F1/F3 on the durable cap).
+                // A reap is BLAMELESS: the task did nothing wrong, its claimer died or restarted.
+                // Under the cap, every reap would otherwise cost that task one claim permanently —
+                // and 2,408 real tasks have already been reaped >=12 times (max 438), so agent
+                // lifecycle noise alone would have parked them. Refunding the claim the reap is
+                // undoing keeps the counter measuring what it says it measures: claims actually
+                // spent trying to do the work. This also covers F3's other blameless consumer —
+                // a transient pgQuery failure in claimTask() leaves the row in 'doing' and it
+                // arrives here an hour later.
+                // GREATEST(...,0) so a refund can never drive the counter negative; the status
+                // re-check stays INSIDE the statement (not a second round-trip) so two reapers
+                // racing the same row cannot both refund it.
+                let reaped;
+                try {
+                    reaped = await pgQuery(
+                        ConstitutionalAgentV4.REAP_SQL,
+                        ConstitutionalAgentV4.buildReapParams(task.id, updatedMetadata),
+                        { retries: 1, timeoutMs: LOOP_TIMEOUTS.DB_QUERY, label: 'runStaleTaskReaper(release)' }
+                    );
+                } catch (updateError) {
                     console.error(`[REAPER] ❌ Failed to reap task ${task.id}:`, updateError.message);
-                } else {
-                    console.log(`[REAPER] ✅ Released task ${task.id} from ${task.claimed_by} (was claimed ${task.claimed_at})`);
-                    await this.log('task_reaped', `Released stale task ${task.id} from ${task.claimed_by}`, {
-                        taskId: task.id,
-                        originalClaimer: task.claimed_by,
-                        claimedAt: task.claimed_at
-                    });
+                    continue;
                 }
+                if (!reaped || reaped.length === 0) {
+                    // Another reaper won the race, or the task left 'doing' on its own. Not an error.
+                    continue;
+                }
+                const refundedTo = reaped[0].claim_count;
+                console.log(`[REAPER] ✅ Released task ${task.id} from ${task.claimed_by} (was claimed ${task.claimed_at}); claim refunded → claim_count=${refundedTo}`);
+                await this.log('task_reaped', `Released stale task ${task.id} from ${task.claimed_by}`, {
+                    taskId: task.id,
+                    originalClaimer: task.claimed_by,
+                    claimedAt: task.claimed_at,
+                    claimCountAfterRefund: refundedTo
+                });
             }
         } catch (e) {
             console.error(`[REAPER] ❌ Reaper exception:`, e.message);
@@ -2008,7 +2022,14 @@ VIRTUE: ${this.wisdom.primaryVirtue}
                     ...(task.metadata || {}),
                     provider_used: result.provider,
                     provider: result.provider
-                }
+                },
+                // DURABLE ANALOGUE of the claimHistory.delete() on the next line (Beat 44,
+                // verifier F4). The in-memory retry counter this cap replaced was cleared on
+                // success; claim_count was not, making it a monotone lifetime counter that only
+                // ever moved toward parking. The honest semantic for a cap is CONSECUTIVE
+                // UNPRODUCTIVE claims. Reset only on a real 'done' — 'needs_artifact' is exactly
+                // the unproductive outcome the cap exists to bound, so it keeps its count.
+                ...(finalStatus === 'done' ? { claim_count: 0 } : {})
             }).eq('id', task.id);
 
             // Reset blacklisted status on success
@@ -2817,6 +2838,47 @@ ConstitutionalAgentV4.CLAIM_SQL =
 ConstitutionalAgentV4.buildClaimParams = function (agentName, now, blacklist, capFilter) {
     return [agentName, now, ConstitutionalAgentV4.CLAIMABLE_STATUSES, blacklist, capFilter,
         ConstitutionalAgentV4.maxTaskClaims()];
+};
+// --- CLAIM REFUND ON REAP (2026-07-27, Beat 44 — verifier F1/F3) ---
+// The statuses runStaleTaskReaper() reclaims FROM. Kept separate from CLAIMABLE_STATUSES: those
+// are the statuses a task is served from, these are the in-flight statuses it is rescued from.
+ConstitutionalAgentV4.REAPABLE_STATUSES = ['doing', 'in_progress'];
+// The reaper's release, as one statement, so the refund is exact under concurrency for the same
+// reason the claim is. GREATEST(...,0) makes the refund saturating rather than signed — a counter
+// that can go negative is a cap that can be farmed by provoking reaps.
+ConstitutionalAgentV4.REAP_SQL =
+    `UPDATE trinity_tasks
+        SET status = 'pending', claimed_by = NULL, claimed_at = NULL,
+            claim_count = GREATEST(COALESCE(claim_count, 0) - 1, 0),
+            metadata = $2::jsonb
+      WHERE id = $1 AND status = ANY($3)
+      RETURNING id, claim_count`;
+ConstitutionalAgentV4.buildReapParams = function (taskId, metadata) {
+    return [taskId, JSON.stringify(metadata ?? {}), ConstitutionalAgentV4.REAPABLE_STATUSES];
+};
+// --- RECOVERY SURFACE (2026-07-27, Beat 44 — verifier F2) ---
+// F2 was that `claim_count` was written by the claim and read by NOTHING: no query, worker, cron
+// or UI in either repo. A parked task produced no human-visible signal and recovery needed a
+// hand-written UPDATE. These two statements plus scripts/ops/claim-exhausted.js are that missing
+// read side. They are hoisted here (rather than living only in the script) so the test suite pins
+// them against the cap the live claim actually enforces — a recovery tool that looks for the wrong
+// threshold is worse than none, because it reports "nothing parked" while tasks sit parked.
+ConstitutionalAgentV4.EXHAUSTED_TASKS_SQL =
+    `SELECT id, title, task_type, status, claim_count, updated_at
+       FROM trinity_tasks
+      WHERE COALESCE(claim_count, 0) >= $1
+        AND status = ANY($2)
+      ORDER BY claim_count DESC, updated_at DESC
+      LIMIT $3`;
+// Recovery is deliberately a RESET, not a raise: raising the cap un-parks every exhausted task at
+// once, which is how the 365-claim runaway would return. $1 scopes it to one task on purpose.
+ConstitutionalAgentV4.RESET_CLAIM_COUNT_SQL =
+    `UPDATE trinity_tasks SET claim_count = 0 WHERE id = $1 RETURNING id, claim_count, status`;
+// Pure predicate mirroring the live claim's `COALESCE(claim_count,0) < $6` guard, so callers and
+// tests can ask "is this parked?" without reimplementing the boundary (which is exclusive).
+ConstitutionalAgentV4.isClaimExhausted = function (task, maxClaims) {
+    const cap = maxClaims == null ? ConstitutionalAgentV4.maxTaskClaims() : maxClaims;
+    return ((task && task.claim_count) || 0) >= cap;
 };
 // Pure mirror of CLAIM_SQL's selector, for tests that need to exercise the CYCLE rather than the
 // string. It is deliberately a mirror and not the source of truth: the accompanying test asserts

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -701,9 +701,9 @@ class ConstitutionalAgentV4 {
             const { data: stale, error } = await this.supabase
                 .from('trinity_tasks')
                 .select('id, claimed_by, claimed_at, title, metadata')
-                .in('status', ['doing', 'in_progress'])
-                .lt('claimed_at', new Date(Date.now() - 60 * 60 * 1000).toISOString())
-                .limit(50);
+                .in('status', ConstitutionalAgentV4.REAPABLE_STATUSES)
+                .lt('claimed_at', new Date(Date.now() - ConstitutionalAgentV4.REAP_STALE_AFTER_MS).toISOString())
+                .limit(ConstitutionalAgentV4.REAP_BATCH_LIMIT);
 
             if (error) {
                 console.error(`[${this.name}] ❌ Reaper query error:`, error.message);
@@ -2873,22 +2873,50 @@ ConstitutionalAgentV4.buildClaimParams = function (agentName, now, blacklist, ca
 // The statuses runStaleTaskReaper() reclaims FROM. Kept separate from CLAIMABLE_STATUSES: those
 // are the statuses a task is served from, these are the in-flight statuses it is rescued from.
 ConstitutionalAgentV4.REAPABLE_STATUSES = ['doing', 'in_progress'];
+// --- THE REAPER'S TRIGGER CONDITIONS, HOISTED (2026-07-27, Beat 45 — round-2 verifier, HIGH #1) ---
+// These were inline literals inside runStaleTaskReaper() and pinned by nothing: the test's supabase
+// stub accepted and discarded every argument. Mutating the staleness window from one HOUR to one
+// SECOND left all 44 tests green — and that mutation alone neutralises the entire cap, because the
+// reaper would rip tasks back mid-work and refund the claim before it could ever accumulate. That is
+// precisely the runaway this PR exists to stop, invisible to the PR's own suite. A background job
+// that WRITES the cap counter cannot have unpinned trigger conditions.
+ConstitutionalAgentV4.REAP_STALE_AFTER_MS = 60 * 60 * 1000;
+ConstitutionalAgentV4.REAP_BATCH_LIMIT = 50;
+// The status a reaped task is released BACK to. Must be in CLAIMABLE_STATUSES or the reap is a
+// permanent strand rather than a rescue — releasing to 'blocked' left every test green.
+ConstitutionalAgentV4.REAP_RELEASE_STATUS = 'pending';
+// The ONLY status whose claim is refunded. 'doing' is what CLAIM_SQL sets, and CLAIM_SQL is the only
+// path that INCREMENTS the counter. The base class (constitutional-agent-base.js:1441/:1491) and
+// w3c.index.js:241 move tasks to 'in_progress' without incrementing anything; refunding those was a
+// pure downward driver on the counter — claim uncounted, reap, −1 — which drains the cap to zero and
+// disables it. Reaped either way (the rescue is the point); refunded only where a claim was spent.
+ConstitutionalAgentV4.REFUNDABLE_STATUS = 'doing';
 // The reaper's release, as one statement, so the refund is exact under concurrency for the same
 // reason the claim is. GREATEST(...,0) makes the refund saturating rather than signed — a counter
-// that can go negative is a cap that can be farmed by provoking reaps.
+// that can go negative is a cap that can be farmed by provoking reaps. `status` on the right-hand
+// side of SET is the OLD row value, so the CASE tests what the task was claimed as.
 ConstitutionalAgentV4.REAP_SQL =
     `UPDATE trinity_tasks
-        SET status = 'pending', claimed_by = NULL, claimed_at = NULL,
-            claim_count = GREATEST(COALESCE(claim_count, 0) - 1, 0),
+        SET status = '${ConstitutionalAgentV4.REAP_RELEASE_STATUS}', claimed_by = NULL, claimed_at = NULL,
+            claim_count = CASE WHEN status = '${ConstitutionalAgentV4.REFUNDABLE_STATUS}'
+                               THEN GREATEST(COALESCE(claim_count, 0) - 1, 0)
+                               ELSE COALESCE(claim_count, 0) END,
             metadata = $2::jsonb
       WHERE id = $1 AND status = ANY($3)
       RETURNING id, claim_count`;
-// How many CONSECUTIVE reap failures end the batch. Must stay strictly under direct-pg's
-// 5-consecutive-failure circuit-breaker threshold, because that breaker is process-wide: if this
-// background janitor trips it, getNextTask/claimTask/heartbeat all throw for five minutes and the
-// fleet idles. Counting consecutive (not total) failures means a transient blip does not abandon
-// a batch of genuinely stale tasks.
-ConstitutionalAgentV4.REAP_FAILURE_BUDGET = 3;
+// How many CONSECUTIVE reap failures end the batch, because the reap runs through direct-pg's
+// PROCESS-WIDE breaker: N consecutive fully-failed calls open a 5-minute cool-down that throws for
+// every caller, getNextTask and the heartbeat included.
+//
+// STATED HONESTLY, because the previous comment here claimed more than the code delivers: the
+// reaper CANNOT guarantee it never opens that breaker. The failure counter is global and is reset
+// only by a success, so the reaper's abandonment does not clear it — successive passes accumulate.
+// What is guaranteed, and what the invariant below pins, is that TWO full failing passes still stay
+// under the threshold (2 x 2 < 5). Three can reach it; by then getNextTask is failing on every poll
+// anyway and the reaper is not the marginal cause. The budget is asserted against direct-pg's
+// exported threshold rather than a duplicated literal, so lowering that threshold breaks the test
+// instead of silently making this guard useless.
+ConstitutionalAgentV4.REAP_FAILURE_BUDGET = 2;
 ConstitutionalAgentV4.buildReapParams = function (taskId, metadata) {
     return [taskId, JSON.stringify(metadata ?? {}), ConstitutionalAgentV4.REAPABLE_STATUSES];
 };

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -716,6 +716,16 @@ class ConstitutionalAgentV4 {
 
             console.log(`[REAPER] 🧹 ${this.name} found ${stale.length} stale tasks to release`);
 
+            // BREAKER GUARD (2026-07-27, Beat 44 — raised by the verification of this very commit).
+            // Moving the release from supabase-js to pgQuery put this background janitor behind
+            // direct-pg's PROCESS-WIDE circuit breaker: 5 consecutive fully-failed calls open a
+            // 5-minute cool-down that throws for EVERY caller. Because the loop below continues
+            // past a failure, a systemic DB problem across a <=50-row batch would guarantee those
+            // 5 failures — and take getNextTask, claimTask and the heartbeat down with it for five
+            // minutes. A janitor must never be able to idle the fleet's claim path. Giving up
+            // after a few consecutive failures keeps this loop below the breaker's threshold; the
+            // tasks are still stale on the next pass, so nothing is lost by stopping early.
+            let consecutiveFailures = 0;
             for (const task of stale) {
                 const updatedMetadata = task.metadata || {};
                 updatedMetadata.reap_count = (updatedMetadata.reap_count || 0) + 1;
@@ -742,8 +752,13 @@ class ConstitutionalAgentV4 {
                     );
                 } catch (updateError) {
                     console.error(`[REAPER] ❌ Failed to reap task ${task.id}:`, updateError.message);
+                    if (++consecutiveFailures >= ConstitutionalAgentV4.REAP_FAILURE_BUDGET) {
+                        console.error(`[REAPER] ⛔ ${consecutiveFailures} consecutive failures — abandoning this batch before the shared pg circuit breaker opens on the claim path`);
+                        return;
+                    }
                     continue;
                 }
+                consecutiveFailures = 0;
                 if (!reaped || reaped.length === 0) {
                     // Another reaper won the race, or the task left 'doing' on its own. Not an error.
                     continue;
@@ -1792,8 +1807,11 @@ CRITERIA: ${task.success_criteria}
         // FIX: count claims DURABLY, in the claim statement itself, and refuse to serve a task past
         // the cap. Counting at CLAIM time (not at release time) is what makes this total: it bounds
         // every release path that exists today and every one added later, without enumerating them.
-        // NOTE: an exhausted task stays 'pending' but stops being served — it is parked, not lost,
-        // and the escalation/HITL rows that accompany these cycles are how a human finds it.
+        // NOTE: an exhausted task stays 'pending' but stops being served. The original note here
+        // claimed the escalation/HITL rows these cycles generate are how a human finds it. That was
+        // REFUTED [V sql:2026-07-27]: trinity_hitl_requests holds 259,432 pending and 1 approved,
+        // ever (2026-02-08), and the callback handler never writes trinity_tasks. The real recovery
+        // surface is scripts/ops/claim-exhausted.js, which ships with this cap for that reason.
         const CAPABILITY_FILTER = process.env.CAPABILITY_FILTER === 'true';
         const HANDLED = (process.env.AGENT_TASK_TYPES ||
             'peer_verify,review,meta,system,research,code,docs,artifact,critique')
@@ -2022,14 +2040,24 @@ VIRTUE: ${this.wisdom.primaryVirtue}
                     ...(task.metadata || {}),
                     provider_used: result.provider,
                     provider: result.provider
-                },
-                // DURABLE ANALOGUE of the claimHistory.delete() on the next line (Beat 44,
-                // verifier F4). The in-memory retry counter this cap replaced was cleared on
-                // success; claim_count was not, making it a monotone lifetime counter that only
-                // ever moved toward parking. The honest semantic for a cap is CONSECUTIVE
-                // UNPRODUCTIVE claims. Reset only on a real 'done' — 'needs_artifact' is exactly
-                // the unproductive outcome the cap exists to bound, so it keeps its count.
-                ...(finalStatus === 'done' ? { claim_count: 0 } : {})
+                }
+                // NO claim_count RESET HERE — DELIBERATELY, and this is the second answer to
+                // verifier F4 ("nothing resets claim_count, and the counter it replaces did").
+                // The first answer was a reset gated on finalStatus === 'done'. An independent
+                // verification then showed it was decorative AND wrong:
+                //   (a) it can never matter — enumerating every write to a claimable status in
+                //       this file (:854, :1522, :1584, :1613, :1926, :1974, :2393, :2417 — all
+                //       new-row INSERTs, releaseTask(), or the escalation path, none reachable
+                //       after this update), a row that completes leaves CLAIMABLE_STATUSES for
+                //       good, so its count cannot affect whether anything is served; and
+                //   (b) its premise is falsified by a live DB trigger. `enable_and_enforce_artifact()`
+                //       (BEFORE UPDATE) rewrites status -> 'needs_artifact' when the app writes
+                //       'done' with no artifact and a body under MIN_ARTIFACT_CHARS. The app would
+                //       therefore zero the counter believing the task was done while the row landed
+                //       as the exact unproductive outcome the cap exists to bound.
+                // A no-op that a commit message calls a fix is worse than an acknowledged gap, so
+                // it is dropped rather than kept for symmetry. The counter stays monotone by
+                // design; the reap refund is what keeps it from being monotone AGAINST the task.
             }).eq('id', task.id);
 
             // Reset blacklisted status on success
@@ -2801,7 +2829,9 @@ ConstitutionalAgentV4.MIN_ARTIFACT_CHARS = 40;
 // (#25): an escalated task is re-offered to the pool. That is exactly why an unbounded cycle was
 // possible, and why the cap below has to be durable rather than in-memory.
 ConstitutionalAgentV4.CLAIMABLE_STATUSES = ['pending', 'todo', 'assigned', 'pending_clarification'];
-// How many times a single task may be claimed, ever, across all agents and restarts. Env-tunable
+// How many times a single task may be claimed across all agents and restarts, NOT counting claims
+// that a stale-task reap later refunded (see REAP_SQL — a reap is blameless, so it gives the claim
+// back). The earlier wording here said "ever", which the refund makes false. Env-tunable
 // so it can be raised without a deploy. 12 = comfortably above any legitimate retry pattern
 // (MAX_CLAIM_RETRIES is 3, per agent) and far below the 365 observed on task 435029.
 ConstitutionalAgentV4.DEFAULT_MAX_TASK_CLAIMS = 12;
@@ -2853,6 +2883,12 @@ ConstitutionalAgentV4.REAP_SQL =
             metadata = $2::jsonb
       WHERE id = $1 AND status = ANY($3)
       RETURNING id, claim_count`;
+// How many CONSECUTIVE reap failures end the batch. Must stay strictly under direct-pg's
+// 5-consecutive-failure circuit-breaker threshold, because that breaker is process-wide: if this
+// background janitor trips it, getNextTask/claimTask/heartbeat all throw for five minutes and the
+// fleet idles. Counting consecutive (not total) failures means a transient blip does not abandon
+// a batch of genuinely stale tasks.
+ConstitutionalAgentV4.REAP_FAILURE_BUDGET = 3;
 ConstitutionalAgentV4.buildReapParams = function (taskId, metadata) {
     return [taskId, JSON.stringify(metadata ?? {}), ConstitutionalAgentV4.REAPABLE_STATUSES];
 };

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -700,7 +700,7 @@ class ConstitutionalAgentV4 {
             // Find stale tasks
             const { data: stale, error } = await this.supabase
                 .from('trinity_tasks')
-                .select('id, claimed_by, claimed_at, title, metadata')
+                .select(ConstitutionalAgentV4.REAP_SELECT_COLUMNS)
                 .in('status', ConstitutionalAgentV4.REAPABLE_STATUSES)
                 .lt('claimed_at', new Date(Date.now() - ConstitutionalAgentV4.REAP_STALE_AFTER_MS).toISOString())
                 .limit(ConstitutionalAgentV4.REAP_BATCH_LIMIT);
@@ -2873,6 +2873,15 @@ ConstitutionalAgentV4.buildClaimParams = function (agentName, now, blacklist, ca
 // The statuses runStaleTaskReaper() reclaims FROM. Kept separate from CLAIMABLE_STATUSES: those
 // are the statuses a task is served from, these are the in-flight statuses it is rescued from.
 ConstitutionalAgentV4.REAPABLE_STATUSES = ['doing', 'in_progress'];
+// The columns the reaper FETCHES. Hoisted 2026-07-27 (Beat 46 — round-3 verifier, HIGH #1/#2).
+// This was an inline string asserted only by a regex requiring the word `metadata`, so `id` — the
+// value the release statement binds to `WHERE id = $1` — was pinned by nothing. Dropping it left
+// all 28 tests green while making `task.id` undefined in production, which node-pg binds as SQL
+// NULL: `WHERE id = NULL` matches no row, so the reaper would silently reap and refund NOTHING,
+// forever, while still logging as though it were working. The test does not restate this list —
+// it reads the reaper's own source for every `task.<prop>` it dereferences and requires each one
+// to be selected, so adding a consumer without adding its column fails too.
+ConstitutionalAgentV4.REAP_SELECT_COLUMNS = 'id, claimed_by, claimed_at, title, metadata';
 // --- THE REAPER'S TRIGGER CONDITIONS, HOISTED (2026-07-27, Beat 45 — round-2 verifier, HIGH #1) ---
 // These were inline literals inside runStaleTaskReaper() and pinned by nothing: the test's supabase
 // stub accepted and discarded every argument. Mutating the staleness window from one HOUR to one

--- a/lib/direct-pg.js
+++ b/lib/direct-pg.js
@@ -131,4 +131,7 @@ async function closePgPool() {
   }
 }
 
-module.exports = { getPgPool, pgQuery, pgPing, closePgPool };
+// CIRCUIT_BREAKER_THRESHOLD is exported so callers that must stay UNDER it (the stale-task reaper
+// in ConstitutionalAgentV4) can assert against the real value instead of duplicating the literal.
+// A duplicated literal means lowering the threshold here silently disarms that guard.
+module.exports = { getPgPool, pgQuery, pgPing, closePgPool, CIRCUIT_BREAKER_THRESHOLD };

--- a/migrations/2026-07-27_add_trinity_tasks_claim_count.sql
+++ b/migrations/2026-07-27_add_trinity_tasks_claim_count.sql
@@ -1,0 +1,27 @@
+-- Durable re-claim counter for trinity_tasks.
+--
+-- APPLIED TO PRODUCTION 2026-07-27 (Supabase qnnpjhlxljtqyigedwkb) by CC, autonomous loop
+-- Beat 42, BEFORE the code in this PR ships. That ordering is deliberate and load-bearing:
+-- lib/ConstitutionalAgentV4.js now references claim_count in the claim statement, and if the
+-- code reached production first the query would fail with 42703, getNextTask() would catch it
+-- and return null, and EVERY agent would go quietly idle — an outage indistinguishable from an
+-- empty queue. Column first, code second.
+--
+-- WHY: task 435029 was claimed 365 times and produced 239 artifacts from 11 agents in ~1h40m
+-- (~1 LLM call per 25s) [V sql:2026-07-27]. The claim itself is race-safe and was not at fault.
+-- Several paths legitimately release a task back to a claimable status with claimed_by=NULL
+-- (releaseTask -> 'pending', the exception path -> 'pending', escalation ->
+-- 'pending_clarification', which is itself claimable), and the only brake was an in-memory,
+-- per-process, per-agent Map — invisible across agents and lost on restart.
+--
+-- ADD COLUMN with a constant DEFAULT is metadata-only on PG11+, so this does not rewrite the
+-- table. trinity_tasks is a 26-FK hub; adding a column touches none of those constraints.
+
+ALTER TABLE public.trinity_tasks
+    ADD COLUMN IF NOT EXISTS claim_count integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.trinity_tasks.claim_count IS
+    'Durable global re-claim counter, incremented inside the atomic claim UPDATE in '
+    'ConstitutionalAgentV4.getNextTask. Caps unbounded re-claim cycles that in-memory '
+    'per-agent claimHistory cannot see. Added 2026-07-27 (autonomous loop Beat 42) after '
+    'task 435029 was re-claimed 365 times / 239 artifacts by 11 agents.';

--- a/scripts/ops/claim-exhausted.js
+++ b/scripts/ops/claim-exhausted.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * claim-exhausted — the read side of the durable re-claim cap.
+ *
+ * WHY THIS EXISTS. The cap (Beat 42) made `trinity_tasks.claim_count` the thing that stops a
+ * task being served forever. An independent verification (Beat 43, finding F2) found that the
+ * counter was written by the claim and read by NOTHING — no query, no worker, no cron, no UI in
+ * either repo. So a task that hit the cap went quiet with zero human-visible signal, and the only
+ * recovery was a hand-written UPDATE against production. A cap whose only failure mode is silent
+ * is not safe to deploy; this script is the missing surface, and it ships WITH the cap.
+ *
+ * The SQL and the threshold live in ConstitutionalAgentV4 (EXHAUSTED_TASKS_SQL /
+ * RESET_CLAIM_COUNT_SQL / isClaimExhausted) rather than here, so the suite can pin this tool to
+ * the same cap the live claim enforces. A recovery tool that looks for the wrong threshold is
+ * worse than no tool: it reports "nothing parked" while work sits parked.
+ *
+ * USAGE
+ *   node scripts/ops/claim-exhausted.js                 # list parked tasks (read-only, default)
+ *   node scripts/ops/claim-exhausted.js --limit 100
+ *   node scripts/ops/claim-exhausted.js --reset 435029  # un-park ONE task
+ *
+ * There is deliberately no --reset-all. Un-parking everything at once is how the 365-claim
+ * runaway comes back; raising MAX_TASK_CLAIMS has the same effect fleet-wide and is the lever to
+ * reach for only after reading the list.
+ */
+
+const A = require('../../lib/ConstitutionalAgentV4');
+const { pgQuery } = require('../../lib/direct-pg');
+
+const DEFAULT_LIMIT = 50;
+
+function parseArgs(argv) {
+  const args = { mode: 'list', limit: DEFAULT_LIMIT, taskId: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--reset') {
+      args.mode = 'reset';
+      args.taskId = argv[++i];
+    } else if (a === '--limit') {
+      args.limit = Number.parseInt(argv[++i], 10);
+    } else if (a === '--help' || a === '-h') {
+      args.mode = 'help';
+    }
+  }
+  return args;
+}
+
+async function list(limit) {
+  const cap = A.maxTaskClaims();
+  const rows = await pgQuery(
+    A.EXHAUSTED_TASKS_SQL,
+    [cap, A.CLAIMABLE_STATUSES, limit],
+    { retries: 1, timeoutMs: 15_000, label: 'claim-exhausted(list)' }
+  );
+  if (!rows || rows.length === 0) {
+    console.log(`No parked tasks: nothing at or above the cap of ${cap} claims.`);
+    return 0;
+  }
+  console.log(`${rows.length} task(s) parked at or above the cap of ${cap} claims:\n`);
+  for (const r of rows) {
+    console.log(
+      `  #${r.id}  claims=${r.claim_count}  status=${r.status}  type=${r.task_type || 'n/a'}  ` +
+      `updated=${r.updated_at || 'n/a'}\n      ${String(r.title || '').slice(0, 100)}`
+    );
+  }
+  console.log(`\nTo un-park one:  node scripts/ops/claim-exhausted.js --reset <id>`);
+  return rows.length;
+}
+
+async function reset(taskId) {
+  if (!taskId || !/^\d+$/.test(String(taskId))) {
+    // trinity_tasks.id is BIGINT (CLAUDE-RULE-5), never a uuid.
+    console.error('--reset needs a numeric task id, e.g. --reset 435029');
+    process.exitCode = 2;
+    return;
+  }
+  const rows = await pgQuery(
+    A.RESET_CLAIM_COUNT_SQL,
+    [taskId],
+    { retries: 1, timeoutMs: 15_000, label: 'claim-exhausted(reset)' }
+  );
+  if (!rows || rows.length === 0) {
+    console.error(`No task #${taskId}.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Task #${rows[0].id} un-parked: claim_count=${rows[0].claim_count}, status=${rows[0].status}.`);
+  console.log('It will be served again on the next poll. If it parks a second time, the task is');
+  console.log('the problem, not the cap — read its artifacts before resetting it again.');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.mode === 'help') {
+    console.log(require('fs').readFileSync(__filename, 'utf8').split('*/')[0]);
+    return;
+  }
+  if (args.mode === 'reset') return reset(args.taskId);
+  return list(Number.isFinite(args.limit) && args.limit > 0 ? args.limit : DEFAULT_LIMIT);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('claim-exhausted failed:', e.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { parseArgs, DEFAULT_LIMIT };

--- a/scripts/ops/claim-exhausted.js
+++ b/scripts/ops/claim-exhausted.js
@@ -91,12 +91,15 @@ async function reset(taskId) {
   console.log('the problem, not the cap — read its artifacts before resetting it again.');
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
   if (args.mode === 'help') {
     console.log(require('fs').readFileSync(__filename, 'utf8').split('*/')[0]);
     return;
   }
+  // Each action gets the field parsed FOR it. Crossing them (reset(args.limit)) is a one-character
+  // edit that turns "un-park task 42" into "un-park task 20, the default list limit" — it targets a
+  // real, arbitrary row and reports success. Pinned end-to-end from argv rather than by inspection.
   if (args.mode === 'reset') return reset(args.taskId);
   return list(Number.isFinite(args.limit) && args.limit > 0 ? args.limit : DEFAULT_LIMIT);
 }
@@ -115,4 +118,9 @@ if (require.main === module) {
 // cap+1 — each left the whole suite green while making the tool print "No parked tasks" forever.
 // That is precisely the silent failure the header warns about, so the behaviour is now reachable
 // from a test rather than only from production.
-module.exports = { parseArgs, list, reset, DEFAULT_LIMIT };
+//
+// `main` is exported for the round-2 follow-up of the SAME finding: exporting the PARTS still left
+// the tool's only real entry point untested, and `return reset(args.limit)` — passing the list
+// limit where a task id belongs — survived the entire suite. The wiring between parseArgs and the
+// two actions is itself behaviour, so it is now reachable from a test rather than trusted.
+module.exports = { parseArgs, list, reset, main, DEFAULT_LIMIT };

--- a/scripts/ops/claim-exhausted.js
+++ b/scripts/ops/claim-exhausted.js
@@ -108,4 +108,11 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseArgs, DEFAULT_LIMIT };
+// `list` and `reset` are exported for the SAME reason the SQL is hoisted into
+// ConstitutionalAgentV4: an independent verification found that pinning the SQL string is not
+// pinning what this tool BINDS. Three one-line mutations — binding REAPABLE_STATUSES instead of
+// CLAIMABLE_STATUSES, binding DEFAULT_MAX_TASK_CLAIMS instead of maxTaskClaims(), or binding
+// cap+1 — each left the whole suite green while making the tool print "No parked tasks" forever.
+// That is precisely the silent failure the header warns about, so the behaviour is now reachable
+// from a test rather than only from production.
+module.exports = { parseArgs, list, reset, DEFAULT_LIMIT };

--- a/tests/claimCallSite.test.js
+++ b/tests/claimCallSite.test.js
@@ -31,6 +31,13 @@ const Module = require('node:module');
 // to happen first. Pre-seeding require.cache is the plain-node equivalent of jest.mock (this repo
 // has no jest: tests are bare `node tests/*.test.js` scripts).
 const PG_PATH = require.resolve('../lib/direct-pg');
+// Capture the REAL breaker threshold before the stub replaces the module. The reap budget has to
+// stay under this number, and the round-2 verification found the old test asserting against a
+// literal 5 copied into the test file — so lowering direct-pg's threshold would have left the
+// suite green while silently disarming the guard. Read from the real module, not duplicated.
+// (Importing it is side-effect-free: the pool is lazy, only constants run at module scope.)
+const REAL_CIRCUIT_BREAKER_THRESHOLD = require('../lib/direct-pg').CIRCUIT_BREAKER_THRESHOLD;
+delete require.cache[PG_PATH];
 const calls = [];
 let nextResult = [];
 let nextThrow = null;
@@ -180,13 +187,30 @@ async function run() {
 
   // ---------- the reaper: the refund actually sent ----------
 
-  /** Supabase stub returning one stale row from the reaper's select. */
+  /**
+   * Supabase stub returning stale rows from the reaper's select — and RECORDING what the reaper
+   * actually asked for.
+   *
+   * The first version of this stub implemented select/in/lt/limit as argument-ignoring chainables.
+   * The round-2 verification showed what that cost: mutating the staleness window from one HOUR to
+   * one SECOND left all 44 tests green, and that single mutation neutralises the whole cap — a
+   * 1-second window rips tasks back mid-work and refunds the claim before the counter can ever
+   * accumulate, reproducing exactly the runaway this PR exists to stop. Four further
+   * trigger-condition mutations (status filter, batch size, survivor gate, release status) were
+   * equally invisible. A stub that discards its arguments does not test a query; it tests only
+   * that some query was issued.
+   */
   function staleSupabase(rows) {
+    const seen = { table: null, select: null, in: [], lt: [], limit: null };
     const q = {
-      select: () => q, in: () => q, lt: () => q,
-      limit: async () => ({ data: rows, error: null }),
+      select: (cols) => { seen.select = cols; return q; },
+      in: (col, vals) => { seen.in.push([col, vals]); return q; },
+      lt: (col, val) => { seen.lt.push([col, val]); return q; },
+      limit: async (n) => { seen.limit = n; return { data: rows, error: null }; },
     };
-    return { from: () => q };
+    const client = { from: (t) => { seen.table = t; return q; } };
+    client.seen = seen;
+    return client;
   }
 
   await test('the reaper refunds the claim it is undoing', async () => {
@@ -202,7 +226,7 @@ async function run() {
     await a.runStaleTaskReaper();
     assert.equal(calls.length, 1, 'the reaper must release through one statement');
     assert.equal(calls[0].sql, A.REAP_SQL);
-    assert.match(A.REAP_SQL.replace(/\s+/g, ' '), /claim_count = GREATEST\(COALESCE\(claim_count, 0\) - 1, 0\)/,
+    assert.match(A.REAP_SQL.replace(/\s+/g, ' '), /THEN GREATEST\(COALESCE\(claim_count, 0\) - 1, 0\)/,
       'the release must refund the claim, saturating at zero');
     assert.equal(logged[0].kind, 'task_reaped');
     assert.equal(logged[0].meta.claimCountAfterRefund, 4, 'the refunded count must be recorded, not just logged to stdout');
@@ -344,6 +368,46 @@ async function run() {
     process.exitCode = prior;
   });
 
+  await test('main() routes each mode to the action with the field parsed FOR it', async () => {
+    const script = require('../scripts/ops/claim-exhausted');
+    // Round-2 verifier, MEDIUM: exporting parseArgs/list/reset still left the tool's only real
+    // entry point untested. `return reset(args.taskId)` -> `reset(args.limit)` survived the whole
+    // suite — and it does not fail loudly. It resets task #20 (the default list limit), reports
+    // success, and leaves the task the operator actually meant still parked.
+    const prior = process.exitCode;
+    const cases = [
+      { argv: ['--reset', '4242'], sql: () => A.RESET_CLAIM_COUNT_SQL, bind: 4242 },
+      { argv: ['--limit', '4242'], sql: () => A.EXHAUSTED_TASKS_SQL, bind: 4242 },
+    ];
+    for (const c of cases) {
+      calls.length = 0;
+      nextResult = [{ id: 4242, claim_count: 12, status: 'pending', title: 't', updated_at: null, metadata: {} }];
+      await script.main(c.argv);
+      assert.equal(calls.length, 1, `${c.argv.join(' ')} sent ${calls.length} statements, expected 1`);
+      assert.equal(calls[0].sql, c.sql(), `${c.argv.join(' ')} sent the wrong statement`);
+      // Loose compare: parseArgs keeps the id as the raw argv string and the limit as a number.
+      assert.ok(calls[0].params.map(String).includes(String(c.bind)),
+        `${c.argv.join(' ')} did not carry ${c.bind} to the wire — the modes' fields are crossed`);
+    }
+    // 4242 is deliberately distinct from DEFAULT_LIMIT and from the cap, so a crossed field cannot
+    // coincide with a plausible-looking value and pass.
+    assert.notEqual(4242, script.DEFAULT_LIMIT);
+    assert.notEqual(4242, A.maxTaskClaims());
+    process.exitCode = prior;
+  });
+
+  await test('main() --help prints and touches no database at all', async () => {
+    const script = require('../scripts/ops/claim-exhausted');
+    const prior = process.exitCode;
+    const log = console.log;
+    console.log = () => {};
+    try {
+      calls.length = 0;
+      await script.main(['--help']);
+      assert.equal(calls.length, 0, 'help must not query');
+    } finally { console.log = log; process.exitCode = prior; }
+  });
+
   await test('a failing reap abandons the batch before it can open the shared pg breaker', async () => {
     // The reap moved to pgQuery, which sits behind direct-pg's PROCESS-WIDE circuit breaker:
     // 5 consecutive failed calls open a 5-minute cool-down that throws for every caller —
@@ -351,7 +415,12 @@ async function run() {
     // batch would guarantee that, letting a background janitor idle the fleet's claim path.
     // (The zero-row path was pinned earlier; this is the THROW path, which was left unpinned in
     // the first version of this file even though the harness already had nextThrow.)
-    assert.ok(A.REAP_FAILURE_BUDGET < 5, 'the budget must stay under direct-pg\'s 5-failure breaker threshold');
+    // Asserted against the REAL exported threshold, not a literal copied into this file. And the
+    // property is the doubled one, because the failure counter is global and the reaper's
+    // abandonment does not reset it: what is actually guaranteed is that TWO full failing passes
+    // stay under the threshold. The old `< 5` let 3 -> 4 pass while making that false.
+    assert.ok(2 * A.REAP_FAILURE_BUDGET < REAL_CIRCUIT_BREAKER_THRESHOLD,
+      `two full failing reaper passes (2 x ${A.REAP_FAILURE_BUDGET}) must stay under direct-pg's ${REAL_CIRCUIT_BREAKER_THRESHOLD}-failure breaker`);
     const rows = Array.from({ length: 20 }, (_, i) => (
       { id: 100 + i, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }));
     const a = agent({ supabase: staleSupabase(rows) });
@@ -359,6 +428,88 @@ async function run() {
     await a.runStaleTaskReaper();
     assert.equal(calls.length, A.REAP_FAILURE_BUDGET,
       `expected the reaper to stop after ${A.REAP_FAILURE_BUDGET} consecutive failures, not to walk all 20 rows`);
+  });
+
+  // ---------- the reaper: the TRIGGER CONDITIONS (round-2 verifier, HIGH #1) ----------
+  // Every assertion below was absent, and every one of these mutations survived the full 44-test
+  // suite. They are grouped so it is obvious what class of defect was invisible: not the SQL the
+  // reaper sends, which was well pinned, but WHEN it decides to send it.
+
+  await test('the reaper only reaps tasks stale by a FULL HOUR, not by a moment', async () => {
+    // THE ONE THAT MATTERS. `Date.now() - 60*60*1000` -> `- 1000` left 44/44 green while completely
+    // neutralising the cap: a 1-second window reaps tasks mid-work and refunds the claim before the
+    // counter can accumulate, which is the 365-claims-in-100-minutes runaway this PR exists to stop.
+    // A tolerance rather than an equality because the reaper stamps its own `now`.
+    const sb = staleSupabase([]);
+    const before = Date.now();
+    await agent({ supabase: sb }).runStaleTaskReaper();
+    const after = Date.now();
+
+    assert.equal(sb.seen.lt.length, 1, 'the reaper must bound staleness with exactly one lt()');
+    const [col, iso] = sb.seen.lt[0];
+    assert.equal(col, 'claimed_at', 'staleness is measured from when the task was CLAIMED');
+    const cutoff = Date.parse(iso);
+    assert.ok(Number.isFinite(cutoff), 'the cutoff must be a parseable ISO timestamp');
+    // The cutoff must sit REAP_STALE_AFTER_MS in the past, within the runtime of the call itself.
+    assert.ok(before - cutoff >= A.REAP_STALE_AFTER_MS - 1 && after - cutoff <= A.REAP_STALE_AFTER_MS + 5000,
+      `cutoff is ${before - cutoff}ms back; expected ~${A.REAP_STALE_AFTER_MS}ms`);
+    // …and the constant itself is pinned, so shrinking it fails here rather than silently.
+    assert.equal(A.REAP_STALE_AFTER_MS, 60 * 60 * 1000, 'the staleness window is one hour by decision');
+  });
+
+  await test('the reaper reads the in-flight statuses, from the right table, in a bounded batch', async () => {
+    // Mutations that survived: `.in('status', ['pending'])` (reaps nothing, ever — the cap then
+    // never gets its refunds and real tasks park), and `.limit(50)` -> `.limit(50000)` (a batch far
+    // larger than the failure budget can protect, on a path behind a process-wide breaker).
+    const sb = staleSupabase([]);
+    await agent({ supabase: sb }).runStaleTaskReaper();
+    assert.equal(sb.seen.table, 'trinity_tasks');
+    assert.deepEqual(sb.seen.in, [['status', A.REAPABLE_STATUSES]]);
+    assert.equal(sb.seen.limit, A.REAP_BATCH_LIMIT);
+    assert.equal(A.REAP_BATCH_LIMIT, 50);
+    assert.match(String(sb.seen.select), /\bmetadata\b/,
+      'the reaper rewrites metadata, so it must select it or it will clobber the existing object');
+  });
+
+  await test('a non-survivor agent issues NO reaper query at all', async () => {
+    // Deleting `if (!this.isSurvivor) return;` survived because the stub agent is always a survivor.
+    // Every agent reaping means N copies of a 50-row batch racing the same rows every pass.
+    const sb = staleSupabase([{ id: 1, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }]);
+    await agent({ supabase: sb, isSurvivor: false }).runStaleTaskReaper();
+    assert.equal(sb.seen.table, null, 'a non-survivor must not even touch the table');
+    assert.equal(calls.length, 0);
+  });
+
+  await test('the release returns the task to a CLAIMABLE status and clears the claimer', async () => {
+    // Two survivors, both of which strand every reaped task permanently: releasing to 'blocked'
+    // (not in CLAIMABLE_STATUSES, so nothing serves it again) and dropping `claimed_by = NULL`
+    // (CLAIM_SQL requires claimed_by IS NULL, so the row is un-claimable forever). Neither is
+    // detectable by asserting the SQL is "the reap SQL" — the property is what that SQL RESTORES.
+    const sql = A.REAP_SQL.replace(/\s+/g, ' ');
+    assert.ok(A.CLAIMABLE_STATUSES.includes(A.REAP_RELEASE_STATUS),
+      `a reap must release into a claimable status; ${A.REAP_RELEASE_STATUS} is a permanent strand`);
+    assert.ok(sql.includes(`status = '${A.REAP_RELEASE_STATUS}'`), 'the release status left the statement');
+    assert.match(sql, /claimed_by = NULL/, 'without clearing claimed_by the row can never be claimed again');
+    assert.match(sql, /claimed_at = NULL/, 'a stale claimed_at would make the row instantly re-reapable');
+  });
+
+  await test('ONLY a claim that was counted is refunded — the uncapped paths cannot drain the cap', async () => {
+    // Round-2 verifier HIGH #2. constitutional-agent-base.js:1441/:1491 and w3c.index.js:241 move
+    // tasks to 'in_progress' WITHOUT incrementing claim_count. Refunding those was a monotone
+    // downward driver — claim uncounted, reap, -1 — which walks the counter to zero and disables
+    // the cap entirely. 'doing' is the only status CLAIM_SQL sets, and CLAIM_SQL is the only
+    // incrementing path, so the refund is conditioned on it. Both statuses are still RELEASED;
+    // the rescue is the point and is not in question.
+    const sql = A.REAP_SQL.replace(/\s+/g, ' ');
+    assert.equal(A.REFUNDABLE_STATUS, 'doing');
+    assert.match(A.CLAIM_SQL.replace(/\s+/g, ' '), new RegExp(`SET status = '${A.REFUNDABLE_STATUS}'`),
+      'the refundable status must be the one the COUNTED claim sets');
+    assert.match(sql, new RegExp(`claim_count = CASE WHEN status = '${A.REFUNDABLE_STATUS}' THEN GREATEST`),
+      'the refund must be conditional on the claim having been counted');
+    assert.match(sql, /ELSE COALESCE\(claim_count, 0\) END/, 'an uncounted claim must leave the counter alone');
+    // The reap still rescues both, or the uncapped paths would leak claimed rows forever.
+    assert.ok(A.REAPABLE_STATUSES.includes('in_progress'),
+      'in_progress must still be reaped — only its REFUND is withheld');
   });
 
   await test('an intermittent failure does NOT abandon the batch', async () => {

--- a/tests/claimCallSite.test.js
+++ b/tests/claimCallSite.test.js
@@ -1,0 +1,301 @@
+'use strict';
+
+/**
+ * CALL-SITE tests for the durable re-claim cap and its refund.
+ *
+ * WHY A SEPARATE FILE. claimCap.test.js proves the PROPERTY (a task that always releases stops
+ * being served) and the STRING (CLAIM_SQL carries the guards). An independent verification
+ * (Beat 43, finding F5) showed both can hold while the live code caps nothing: it hand-built a
+ * 5-bind array at the getNextTask() call site instead of calling buildClaimParams, and 15/15
+ * tests still passed. Two more variants did the same — sending a de-capped copy of CLAIM_SQL,
+ * and Object.assign-ing the cap bind to 2147483647. `ConstitutionalAgentV4.getNextTask` had
+ * ZERO coverage; tests/getNextTask.test.js exercises a different class entirely
+ * (constitutional-agent-base.js's ConstitutionalAgent).
+ *
+ * The only thing that can see those mutations is asserting on what the method actually SENT.
+ * So this file stubs the pg layer, invokes the real methods, and inspects the wire.
+ *
+ * That failure mode is not academic: a de-capped claim restores the 365-claim runaway, and a
+ * missing bind is worse than a degraded cap — Postgres rejects the statement, getNextTask()
+ * catches and returns null, and all 11 agents go quietly idle looking exactly like an empty queue.
+ *
+ * Run: node tests/claimCallSite.test.js
+ */
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+// --- Stub the pg layer BEFORE ConstitutionalAgentV4 is loaded ------------------------------
+// It destructures `const { pgQuery } = require('./direct-pg')` at module scope, so the swap has
+// to happen first. Pre-seeding require.cache is the plain-node equivalent of jest.mock (this repo
+// has no jest: tests are bare `node tests/*.test.js` scripts).
+const PG_PATH = require.resolve('../lib/direct-pg');
+const calls = [];
+let nextResult = [];
+let nextThrow = null;
+// Per-call result override, for the tests that need the Nth query to answer differently from the
+// first (a reap batch where one row loses the race and the next does not).
+let resultFor = null;
+const stub = {
+  getPgPool: () => { throw new Error('getPgPool must not be called in this test'); },
+  pgQuery: async (sql, params, opts) => {
+    calls.push({ sql, params, opts });
+    if (nextThrow) { const e = nextThrow; nextThrow = null; throw e; }
+    return resultFor ? resultFor() : nextResult;
+  },
+  pgPing: async () => true,
+  closePgPool: async () => {},
+};
+require.cache[PG_PATH] = new Module(PG_PATH, null);
+require.cache[PG_PATH].filename = PG_PATH;
+require.cache[PG_PATH].path = path.dirname(PG_PATH);
+require.cache[PG_PATH].loaded = true;
+require.cache[PG_PATH].exports = stub;
+
+const A = require('../lib/ConstitutionalAgentV4');
+
+// Guard: if the swap silently failed we would be exercising the real pool against no database and
+// every assertion below would be meaningless. Prove the stub is the one in force.
+assert.equal(require('../lib/direct-pg').pgQuery, stub.pgQuery,
+  'the direct-pg stub is not installed — every assertion in this file would be vacuous');
+
+const ORIG_ENV = { ...process.env };
+
+/**
+ * A minimal agent. Built with Object.create so the real constructor (Supabase client, websocket,
+ * express server) never runs: the methods under test read only these fields.
+ */
+function agent(over = {}) {
+  return Object.assign(Object.create(A.prototype), {
+    name: 'trinity-test',
+    claimHistory: new Map(),
+    MAX_CLAIM_RETRIES: 3,
+    isSurvivor: true,
+    log: async () => {},
+    ...over,
+  });
+}
+
+function reset() {
+  calls.length = 0;
+  nextResult = [];
+  nextThrow = null;
+  resultFor = null;
+  process.env = { ...ORIG_ENV };
+}
+
+async function run() {
+  let passed = 0;
+  const test = async (name, fn) => {
+    reset();
+    try {
+      await fn();
+      console.log(`  ok ${name}`);
+      passed++;
+    } catch (e) {
+      console.error(`  FAIL ${name}:`, e.message);
+      process.exitCode = 1;
+    } finally {
+      process.env = { ...ORIG_ENV };
+    }
+  };
+
+  // ---------- getNextTask: the claim actually sent ----------
+
+  await test('getNextTask sends CLAIM_SQL itself, not a copy', async () => {
+    // Kills M16 (a de-capped duplicate of the SQL at the call site). Identity, not similarity:
+    // a near-copy is exactly what a mutation produces.
+    await agent().getNextTask();
+    assert.equal(calls.length, 1, 'expected exactly one query');
+    assert.equal(calls[0].sql, A.CLAIM_SQL, 'the call site did not send CLAIM_SQL');
+  });
+
+  await test('getNextTask sends the cap bind, and it equals the configured cap', async () => {
+    // Kills M15 (hand-built 5-bind array) and M21 (Object.assign to a huge cap).
+    process.env.MAX_TASK_CLAIMS = '7';
+    await agent().getNextTask();
+    const { params } = calls[0];
+    assert.equal(params.length, 6, 'CLAIM_SQL binds $1..$6; a short array is a fleet-wide outage');
+    assert.equal(params[5], 7, 'the cap bind must carry the configured cap, not a default or a sentinel');
+  });
+
+  await test('the bind count is pinned to a LITERAL, not derived from the SQL under test', async () => {
+    // claimCap.test.js derives `highest` with Math.max(...CLAIM_SQL.matchAll(/\$(\d+)/g)), which a
+    // coordinated removal of BOTH $6 and its bind satisfies. Pinning 6 as a literal here is what
+    // makes that mutation visible, so the two files fail for different reasons on purpose.
+    const highest = Math.max(...[...A.CLAIM_SQL.matchAll(/\$(\d+)/g)].map((m) => Number(m[1])));
+    assert.equal(highest, 6, 'CLAIM_SQL must bind exactly $1..$6 — changing this is a deliberate act');
+    await agent().getNextTask();
+    assert.equal(calls[0].params.length, 6);
+  });
+
+  await test('every bind position carries the value the SQL expects at that position', async () => {
+    // Replaces `params.every(p => p !== undefined)`, which is satisfied by any array of nulls.
+    const a = agent();
+    a.claimHistory.set(99, 3); // at MAX_CLAIM_RETRIES => blacklisted
+    await a.getNextTask();
+    const { params } = calls[0];
+    assert.equal(params[0], 'trinity-test', '$1 = agent name');
+    assert.match(String(params[1]), /^\d{4}-\d{2}-\d{2}T/, '$2 = ISO timestamp');
+    assert.deepEqual(params[2], A.CLAIMABLE_STATUSES, '$3 = claimable status set');
+    assert.deepEqual(params[3], [99], '$4 = in-memory blacklist');
+    assert.equal(params[4], null, '$5 = capability filter, NULL when CAPABILITY_FILTER is off');
+    assert.equal(params[5], A.maxTaskClaims(), '$6 = the cap');
+  });
+
+  await test('the env lever reaches the wire end-to-end', async () => {
+    // Verifier F6: replacing maxTaskClaims() with DEFAULT_MAX_TASK_CLAIMS inside buildClaimParams
+    // survived, because the suite ran with MAX_TASK_CLAIMS unset so the two were equal. Raising the
+    // cap without a deploy is the operator's only mitigation for a wrongly-parked task, so it is
+    // tested against a value that CANNOT coincide with the default.
+    process.env.MAX_TASK_CLAIMS = '37';
+    assert.notEqual(37, A.DEFAULT_MAX_TASK_CLAIMS, 'pick a probe value distinct from the default');
+    await agent().getNextTask();
+    assert.equal(calls[0].params[5], 37, 'MAX_TASK_CLAIMS did not reach the claim statement');
+  });
+
+  await test('the default cap is pinned to 12, not merely to "some positive number"', async () => {
+    // Verifier F7: every existing assertion read maxTaskClaims() dynamically, so 12->2 and 12->50
+    // both passed. 2 would park real work; 50 would have let the 365-claim runaway run four times
+    // longer. The magnitude is a decision and is recorded as one.
+    delete process.env.MAX_TASK_CLAIMS;
+    assert.equal(A.DEFAULT_MAX_TASK_CLAIMS, 12);
+    await agent().getNextTask();
+    assert.equal(calls[0].params[5], 12);
+  });
+
+  await test('a query failure returns null instead of throwing into the loop', async () => {
+    nextThrow = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const got = await agent().getNextTask();
+    assert.equal(got, null);
+  });
+
+  await test('getNextTask returns the claimed row', async () => {
+    nextResult = [{ id: 1, title: 't', status: 'doing', claim_count: 1 }];
+    const got = await agent().getNextTask();
+    assert.equal(got.id, 1);
+    assert.equal(got.claim_count, 1);
+  });
+
+  // ---------- the reaper: the refund actually sent ----------
+
+  /** Supabase stub returning one stale row from the reaper's select. */
+  function staleSupabase(rows) {
+    const q = {
+      select: () => q, in: () => q, lt: () => q,
+      limit: async () => ({ data: rows, error: null }),
+    };
+    return { from: () => q };
+  }
+
+  await test('the reaper refunds the claim it is undoing', async () => {
+    // Verifier F1: a reap is blameless — the claimer died or restarted, the task did nothing wrong.
+    // Without the refund each reap costs the task one claim permanently, and 2,408 real tasks have
+    // already been reaped >=12 times (max 438): agent lifecycle noise alone would park them all.
+    nextResult = [{ id: 42, claim_count: 4 }];
+    const logged = [];
+    const a = agent({
+      supabase: staleSupabase([{ id: 42, claimed_by: 'trinity-dead', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }]),
+      log: async (kind, msg, meta) => { logged.push({ kind, meta }); },
+    });
+    await a.runStaleTaskReaper();
+    assert.equal(calls.length, 1, 'the reaper must release through one statement');
+    assert.equal(calls[0].sql, A.REAP_SQL);
+    assert.match(A.REAP_SQL.replace(/\s+/g, ' '), /claim_count = GREATEST\(COALESCE\(claim_count, 0\) - 1, 0\)/,
+      'the release must refund the claim, saturating at zero');
+    assert.equal(logged[0].kind, 'task_reaped');
+    assert.equal(logged[0].meta.claimCountAfterRefund, 4, 'the refunded count must be recorded, not just logged to stdout');
+  });
+
+  await test('the refund saturates at zero rather than going negative', async () => {
+    // A signed counter is a cap that can be farmed: provoke reaps, bank negative claims, then
+    // cycle freely. GREATEST is what makes that impossible, so it is asserted as behaviour.
+    const sql = A.REAP_SQL.replace(/\s+/g, ' ');
+    assert.ok(sql.includes('GREATEST('), 'lost the saturating floor on the refund');
+    assert.ok(!/claim_count = COALESCE\(claim_count, 0\) - 1(?!,)/.test(sql), 'unsaturated decrement');
+  });
+
+  await test('the reaper re-checks status INSIDE the statement, so two reapers cannot both refund', async () => {
+    nextResult = [{ id: 42, claim_count: 0 }];
+    const a = agent({
+      supabase: staleSupabase([{ id: 42, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }]),
+    });
+    await a.runStaleTaskReaper();
+    assert.match(A.REAP_SQL.replace(/\s+/g, ' '), /WHERE id = \$1 AND status = ANY\(\$3\)/,
+      'the status re-check must share the statement with the update, not be a second round-trip');
+    assert.deepEqual(calls[0].params[2], A.REAPABLE_STATUSES);
+    assert.deepEqual(A.REAPABLE_STATUSES, ['doing', 'in_progress']);
+  });
+
+  await test('losing the reap race is skipped cleanly — the batch continues', async () => {
+    // Zero rows means another reaper won, or the task left 'doing' on its own. Two things must be
+    // true and BOTH are asserted: no task_reaped row is emitted for it, and the rest of the batch
+    // still gets reaped.
+    //
+    // The second half is the whole test. A first draft asserted only the absence of the log, and
+    // mutation MR5 (delete the zero-row guard) SURVIVED it: without the guard the code reads
+    // reaped[0].claim_count on an empty array, throws, and the outer catch swallows it — so "no
+    // log" is equally true of the fix and of the defect, while every remaining stale task is
+    // silently abandoned. Absence of a signal is not evidence when the mutant produces the same
+    // absence by crashing.
+    const seen = [];
+    let call = 0;
+    const a = agent({
+      supabase: staleSupabase([
+        { id: 41, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }, // race lost
+        { id: 42, claimed_by: 'y', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }, // must still reap
+      ]),
+      log: async (kind, msg, meta) => { seen.push(meta.taskId); },
+    });
+    resultFor = () => (++call === 1 ? [] : [{ id: 42, claim_count: 3 }]);
+    await a.runStaleTaskReaper();
+    assert.deepEqual(seen, [42], 'the lost race must be skipped, and the next task still reaped');
+    assert.equal(calls.length, 2, 'both rows must be attempted');
+  });
+
+  await test('the reap carries forward reap_count metadata', async () => {
+    nextResult = [{ id: 42, claim_count: 1 }];
+    const a = agent({
+      supabase: staleSupabase([{ id: 42, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: { reap_count: 6 } }]),
+    });
+    await a.runStaleTaskReaper();
+    const meta = JSON.parse(calls[0].params[1]);
+    assert.equal(meta.reap_count, 7);
+    assert.ok(meta.last_reaped_at);
+  });
+
+  // ---------- the recovery surface (verifier F2) ----------
+
+  await test('the recovery query looks for the SAME threshold the claim enforces', async () => {
+    // F2: claim_count was written by the claim and read by nothing, so a parked task produced zero
+    // human-visible signal. A recovery tool pinned to the wrong threshold is worse than none — it
+    // reports "nothing parked" while work sits parked. Both sides are checked against one boundary.
+    const list = A.EXHAUSTED_TASKS_SQL.replace(/\s+/g, ' ');
+    assert.match(list, /COALESCE\(claim_count, 0\) >= \$1/,
+      'the claim serves while count < cap, so recovery must list count >= cap — the same boundary');
+    assert.match(A.CLAIM_SQL.replace(/\s+/g, ' '), /COALESCE\(claim_count, 0\) < \$6/);
+    assert.equal(A.isClaimExhausted({ claim_count: 12 }, 12), true, 'boundary is inclusive on the recovery side');
+    assert.equal(A.isClaimExhausted({ claim_count: 11 }, 12), false);
+    assert.equal(A.isClaimExhausted({ claim_count: null }, 12), false, 'a pre-migration NULL is 0, not parked');
+  });
+
+  await test('recovery resets one task at a time, and cannot un-park the whole queue', async () => {
+    const sql = A.RESET_CLAIM_COUNT_SQL.replace(/\s+/g, ' ');
+    assert.match(sql, /WHERE id = \$1/, 'reset must be scoped to a single id');
+    assert.match(sql, /claim_count = 0/);
+    // Scope the check to the WHERE clause: `claim_count` legitimately appears in RETURNING, and a
+    // regex spanning to end-of-string matches that instead — which is how this assertion failed on
+    // its first draft, against correct SQL.
+    const where = sql.slice(sql.indexOf('WHERE'), sql.indexOf('RETURNING'));
+    assert.ok(!/claim_count/.test(where), 'a predicate on claim_count would allow a mass un-park');
+    const script = require('../scripts/ops/claim-exhausted');
+    assert.equal(script.parseArgs(['--reset', '435029']).taskId, '435029');
+    assert.equal(script.parseArgs([]).mode, 'list', 'the default must be read-only');
+  });
+
+  console.log(`\nclaimCallSite.test.js: ${passed} passed`);
+  if (process.exitCode) console.error('claimCallSite.test.js: FAILURES ABOVE');
+}
+
+run();

--- a/tests/claimCallSite.test.js
+++ b/tests/claimCallSite.test.js
@@ -467,8 +467,51 @@ async function run() {
     assert.deepEqual(sb.seen.in, [['status', A.REAPABLE_STATUSES]]);
     assert.equal(sb.seen.limit, A.REAP_BATCH_LIMIT);
     assert.equal(A.REAP_BATCH_LIMIT, 50);
-    assert.match(String(sb.seen.select), /\bmetadata\b/,
-      'the reaper rewrites metadata, so it must select it or it will clobber the existing object');
+    assert.equal(String(sb.seen.select), A.REAP_SELECT_COLUMNS,
+      'the select must be the hoisted constant, not an inline string only this test can see');
+  });
+
+  await test('every column the reaper CONSUMES is a column it SELECTS', async () => {
+    // Round-3 verifier HIGH #1. The old assertion required only the word `metadata` to appear in
+    // the select string. Dropping `id` -- the value bound to `WHERE id = $1` -- left all 28 tests
+    // green; in production `task.id` becomes undefined, node-pg binds undefined as SQL NULL, and
+    // `WHERE id = NULL` matches nothing. The reaper would reap and refund NOTHING, forever, while
+    // logging as if it had. Nothing about that is visible from outside.
+    //
+    // Deliberately DERIVED, not restated. Re-listing the columns here would pin this test to a
+    // copy of the constant and prove only that two strings written together agree. Reading the
+    // reaper's own source for the properties it dereferences pins the actual invariant -- the
+    // fetch covers the use -- and keeps holding when someone adds a consumer later.
+    const src = String(A.prototype.runStaleTaskReaper);
+    const consumed = [...new Set([...src.matchAll(/\btask\.([A-Za-z_]\w*)/g)].map((m) => m[1]))];
+    assert.ok(consumed.includes('id'),
+      'guard on the guard: if this stops finding `task.id` the extraction broke, not the code');
+    assert.ok(consumed.length >= 3, `expected several consumed columns, found ${consumed.join(',')}`);
+    const selected = A.REAP_SELECT_COLUMNS.split(',').map((c) => c.trim());
+    for (const prop of consumed) {
+      assert.ok(selected.includes(prop),
+        `the reaper reads task.${prop} but never selects it -- it will be undefined at runtime ` +
+        `(select is: ${A.REAP_SELECT_COLUMNS})`);
+    }
+  });
+
+  await test('the reap binds the task id in the position the statement reads it from', async () => {
+    // Round-3 verifier HIGH #2. Bind positions 2 and 3 of buildReapParams were asserted; position
+    // 1 -- the id -- was not, anywhere. Hardcoding it to a constant left all 28 tests green and
+    // produces the same permanent silent no-op as HIGH #1: every reap targets a row that does not
+    // exist. The symmetric test for buildClaimParams already existed; this is the missing twin.
+    const params = A.buildReapParams(4242, { reap_count: 1 });
+    assert.equal(params.length, 3, 'the statement has exactly three placeholders');
+    assert.equal(params[0], 4242, 'the id passed in must reach $1 -- else the reap targets a row at random, or none');
+    assert.deepEqual(JSON.parse(params[1]), { reap_count: 1 }, '$2 carries the rewritten metadata');
+    assert.deepEqual(params[2], A.REAPABLE_STATUSES, '$3 is the in-flight status guard');
+
+    // And the statement really does read the id from $1, so the pairing above is not two halves
+    // that agree with each other while both disagreeing with the SQL.
+    const sql = A.REAP_SQL.replace(/\s+/g, ' ');
+    assert.match(sql, /WHERE id = \$1\b/, 'the id must be bound at $1 for the assertion above to mean anything');
+    assert.match(sql, /metadata = \$2/, '$2 is the metadata position');
+    assert.match(sql, /status = ANY\(\$3\)/, '$3 is the status-guard position');
   });
 
   await test('a non-survivor agent issues NO reaper query at all', async () => {
@@ -488,6 +531,11 @@ async function run() {
     const sql = A.REAP_SQL.replace(/\s+/g, ' ');
     assert.ok(A.CLAIMABLE_STATUSES.includes(A.REAP_RELEASE_STATUS),
       `a reap must release into a claimable status; ${A.REAP_RELEASE_STATUS} is a permanent strand`);
+    // Round-3 verifier, LOW: the only reaper trigger constant without a literal pin. The
+    // structural check above catches an unclaimable value, but 'pending' -> another CLAIMABLE
+    // status passed everything, and where a reaped task lands is a decision, not an
+    // implementation detail. Its three siblings are pinned this way; this one now matches.
+    assert.equal(A.REAP_RELEASE_STATUS, 'pending', 'reaped tasks return to the open pool by decision');
     assert.ok(sql.includes(`status = '${A.REAP_RELEASE_STATUS}'`), 'the release status left the statement');
     assert.match(sql, /claimed_by = NULL/, 'without clearing claimed_by the row can never be claimed again');
     assert.match(sql, /claimed_at = NULL/, 'a stale claimed_at would make the row instantly re-reapable');

--- a/tests/claimCallSite.test.js
+++ b/tests/claimCallSite.test.js
@@ -276,6 +276,35 @@ async function run() {
     await a.runStaleTaskReaper();
     assert.deepEqual(seen, [42], 'the lost race must be skipped, and the next task still reaped');
     assert.equal(calls.length, 2, 'both rows must be attempted');
+
+    // THE WIRE BETWEEN THE FETCH AND THE BIND (round-4 verification, HIGH).
+    // buildReapParams was pinned as a unit (`buildReapParams(4242,…)` → `params[0] === 4242`) and
+    // the select was pinned to cover every `task.<prop>` the reaper dereferences — but NOTHING
+    // asserted that the id reaching buildReapParams is the id of the row being reaped. Four
+    // single-edit mutations of that one call-site argument each left the whole suite green while
+    // turning the reaper into a permanent silent no-op:
+    //   buildReapParams(999999, …)      → WHERE id = 999999 matches nothing; reaps and refunds
+    //                                     NOTHING, forever, logging as though it worked
+    //   buildReapParams(task.claimed_by)→ same, plus 22P02 on a text→bigint bind
+    //   buildReapParams(task.title, …)  → same, and burns the failure budget every pass
+    //   buildReapParams(stale[0].id, …) → reaps the SAME row up to 50x per pass (an infinitely
+    //                                     re-claimable task) while stranding every other row
+    // The two ids here are deliberately DISTINCT so that `stale[0].id` cannot coincide with the
+    // right answer — a single-row batch would pass under that mutant.
+    assert.deepEqual(calls.map((c) => c.params[0]), [41, 42],
+      'each reap must bind the id of the row it is reaping — not a constant, not another column, ' +
+      'and not the first row of the batch repeated');
+
+    // The options are captured by the stub but were asserted nowhere: `retries: 1 → 25` and
+    // dropping the options object entirely both survived. runStaleTaskReaper is wrapped in
+    // withTimeout(15s), which ABANDONS but does not cancel, so a retry storm leaks connections
+    // from a POOL_MAX=5 pool — and REAP_FAILURE_BUDGET's arithmetic assumes one attempt per row.
+    for (const c of calls) {
+      assert.equal(c.opts && c.opts.retries, 1,
+        'the reap must not retry-storm: the failure budget assumes one attempt per row');
+      assert.ok(c.opts && typeof c.opts.timeoutMs === 'number',
+        'the reap must carry an explicit timeout');
+    }
   });
 
   await test('the reap carries forward reap_count metadata', async () => {

--- a/tests/claimCallSite.test.js
+++ b/tests/claimCallSite.test.js
@@ -280,6 +280,99 @@ async function run() {
     assert.equal(A.isClaimExhausted({ claim_count: null }, 12), false, 'a pre-migration NULL is 0, not parked');
   });
 
+  await test('the recovery tool BINDS the cap the claim enforces, including the env override', async () => {
+    // Pinning the SQL string is not pinning what the tool sends. Three one-line mutations left the
+    // whole suite green while making `list()` print "No parked tasks" forever: binding
+    // REAPABLE_STATUSES instead of CLAIMABLE_STATUSES (parked rows are 'pending', never 'doing'),
+    // binding DEFAULT_MAX_TASK_CLAIMS instead of maxTaskClaims() (the operator raises the cap and
+    // the tool ignores it), and binding cap+1 (the first parked task is invisible). Each produces
+    // the exact silent failure the tool's own header says is worse than having no tool.
+    process.env.MAX_TASK_CLAIMS = '5';
+    const script = require('../scripts/ops/claim-exhausted');
+    nextResult = [{ id: 7, title: 't', task_type: 'research', status: 'pending', claim_count: 9, updated_at: null }];
+    await script.list(25);
+    assert.equal(calls[0].sql, A.EXHAUSTED_TASKS_SQL);
+    assert.equal(calls[0].params[0], 5, 'the tool must look for the cap the CLAIM is using, not the default');
+    assert.deepEqual(calls[0].params[1], A.CLAIMABLE_STATUSES,
+      'parked tasks sit in a CLAIMABLE status — searching the in-flight statuses finds nothing, forever');
+    assert.equal(calls[0].params[2], 25, 'the limit must reach the query');
+  });
+
+  await test('the recovery tool resets exactly the task it was asked to', async () => {
+    const script = require('../scripts/ops/claim-exhausted');
+    nextResult = [{ id: 435029, claim_count: 0, status: 'pending' }];
+    await script.reset('435029');
+    assert.equal(calls[0].sql, A.RESET_CLAIM_COUNT_SQL);
+    assert.deepEqual(calls[0].params, ['435029']);
+  });
+
+  await test('the recovery tool refuses a non-numeric id without touching the database', async () => {
+    // trinity_tasks.id is BIGINT (CLAUDE-RULE-5). A flag arriving where an id belongs
+    // (`--reset --limit 5` parses taskId as '--limit') must not reach a query.
+    const script = require('../scripts/ops/claim-exhausted');
+    const prior = process.exitCode;
+    await script.reset('--limit');
+    assert.equal(calls.length, 0, 'a rejected id must not produce a query');
+    process.exitCode = prior;
+  });
+
+  await test('no argv reaches the database with anything but a single numeric id', async () => {
+    // Asserted END-TO-END rather than at the parser, because the two layers disagree and the
+    // parser is the wrong place to look: `--reset all` DOES parse to {mode:'reset', taskId:'all'},
+    // and a first draft of this test failed on exactly that — correctly, since it was checking the
+    // parser when the guard lives in reset(). The property that actually matters is that no
+    // argument list produces a query that could touch more than one row, so that is what is
+    // checked, by driving each argv through to the wire.
+    const script = require('../scripts/ops/claim-exhausted');
+    const prior = process.exitCode;
+    for (const argv of [['--reset-all'], ['--all'], ['--reset', 'all'], ['--reset', '*'],
+      ['--reset', '1 OR 1=1'], ['--reset'], ['--reset', '--limit'], []]) {
+      calls.length = 0;
+      nextResult = [];
+      const a = script.parseArgs(argv);
+      if (a.mode === 'reset') await script.reset(a.taskId);
+      else if (a.mode === 'list') await script.list(a.limit);
+      for (const c of calls) {
+        if (c.sql === A.RESET_CLAIM_COUNT_SQL) {
+          assert.equal(c.params.length, 1, `${argv.join(' ')} sent a reset with more than one bind`);
+          assert.match(String(c.params[0]), /^\d+$/, `${argv.join(' ')} sent a non-numeric id to a reset`);
+        } else {
+          assert.equal(c.sql, A.EXHAUSTED_TASKS_SQL, `${argv.join(' ')} sent an unexpected statement`);
+        }
+      }
+    }
+    process.exitCode = prior;
+  });
+
+  await test('a failing reap abandons the batch before it can open the shared pg breaker', async () => {
+    // The reap moved to pgQuery, which sits behind direct-pg's PROCESS-WIDE circuit breaker:
+    // 5 consecutive failed calls open a 5-minute cool-down that throws for every caller —
+    // getNextTask, claimTask and the heartbeat included. Continuing past failures across a 50-row
+    // batch would guarantee that, letting a background janitor idle the fleet's claim path.
+    // (The zero-row path was pinned earlier; this is the THROW path, which was left unpinned in
+    // the first version of this file even though the harness already had nextThrow.)
+    assert.ok(A.REAP_FAILURE_BUDGET < 5, 'the budget must stay under direct-pg\'s 5-failure breaker threshold');
+    const rows = Array.from({ length: 20 }, (_, i) => (
+      { id: 100 + i, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }));
+    const a = agent({ supabase: staleSupabase(rows) });
+    resultFor = () => { throw new Error('connection refused'); };
+    await a.runStaleTaskReaper();
+    assert.equal(calls.length, A.REAP_FAILURE_BUDGET,
+      `expected the reaper to stop after ${A.REAP_FAILURE_BUDGET} consecutive failures, not to walk all 20 rows`);
+  });
+
+  await test('an intermittent failure does NOT abandon the batch', async () => {
+    // The budget counts CONSECUTIVE failures. A reaper that gave up on the first transient error
+    // would leave stale tasks claimed for another hour — trading one failure mode for another.
+    const rows = Array.from({ length: 6 }, (_, i) => (
+      { id: 200 + i, claimed_by: 'x', claimed_at: '2026-07-27T00:00:00Z', metadata: {} }));
+    const a = agent({ supabase: staleSupabase(rows) });
+    let n = 0;
+    resultFor = () => { n++; if (n % 2 === 1) throw new Error('transient'); return [{ id: 200 + n, claim_count: 1 }]; };
+    await a.runStaleTaskReaper();
+    assert.equal(calls.length, 6, 'alternating failures never reach the consecutive budget');
+  });
+
   await test('recovery resets one task at a time, and cannot un-park the whole queue', async () => {
     const sql = A.RESET_CLAIM_COUNT_SQL.replace(/\s+/g, ' ');
     assert.match(sql, /WHERE id = \$1/, 'reset must be scoped to a single id');

--- a/tests/claimCap.test.js
+++ b/tests/claimCap.test.js
@@ -185,8 +185,16 @@ async function run() {
 
   test('CLAIM_SQL refuses to select a task at or above the cap', () => {
     const sql = A.CLAIM_SQL.replace(/\s+/g, ' ');
-    assert.match(sql, /AND COALESCE\(claim_count, ?0\) < \$6/,
+    // ANCHORED to the end of the predicate. Round-4 verification found the unanchored form
+    // (/< \$6/) is satisfied by anything appended to the right-hand side: `< $6 + 1` (cap
+    // silently 13), `< $6 + 1000000` (cap silently 1,000,012 — the 365-claim runaway returns
+    // with no other symptom and no failing test), and `< $6 OR TRUE` (the whole WHERE
+    // short-circuits, so agents claim rows already claimed by others). All three passed the old
+    // assertion, and the call-site test cannot catch them because the BIND VALUE is unchanged.
+    assert.match(sql, /AND COALESCE\(claim_count, ?0\) < \$6 ORDER BY/,
       'the cap predicate is the whole fix; without it claim_count is just telemetry');
+    assert.ok(!/< \$6 *(\+|OR\b|AND\b)/.test(sql),
+      'nothing may be appended to the cap comparison — a widened right-hand side disarms the cap silently');
   });
 
   test('CLAIM_SQL still carries the race-safety guards it had before', () => {

--- a/tests/claimCap.test.js
+++ b/tests/claimCap.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+/**
+ * Durable re-claim cap — regression tests for the runaway measured on task 435029
+ * (365 claims / 239 artifacts / 11 agents / ~1h40m, ~1 LLM call per 25s).
+ *
+ * The runaway was NOT a claim race: the claim has been a single-row atomic
+ * `UPDATE ... WHERE id = (SELECT ... FOR UPDATE SKIP LOCKED)` since the 2026-06-19
+ * egress fix. It was UNBOUNDED RE-CLAIM — several paths legitimately release a task
+ * back to a claimable status with claimed_by=NULL, and the only brake was an
+ * in-memory, per-process, per-agent Map.
+ *
+ * Two things have to be true for the fix to hold, and they are tested separately
+ * on purpose:
+ *   1. PROPERTY — a task that always releases eventually stops being served.
+ *      Exercised against the pure mirror `selectClaimableTask`.
+ *   2. WIRING — the SQL the live agent actually sends carries the same guards.
+ *      Without this, the mirror could satisfy (1) while the real query capped
+ *      nothing: a mirror that moves with the implementation proves nothing.
+ *
+ * Run: node tests/claimCap.test.js
+ */
+
+const assert = require('node:assert/strict');
+const A = require('../lib/ConstitutionalAgentV4');
+
+const ORIG_ENV = { ...process.env };
+
+/** A task in the shape the selector predicate cares about. */
+function task(id, over = {}) {
+  return {
+    id,
+    status: 'pending',
+    claimed_by: null,
+    assigned_to: null,
+    agent_assigned: null,
+    task_type: 'research',
+    priority: 1,
+    created_at: `2026-07-27T00:00:${String(id % 60).padStart(2, '0')}Z`,
+    claim_count: 0,
+    ...over,
+  };
+}
+
+/** Release a task the way the escalation path does: back to the pool, unclaimed. */
+function releaseToPool(t, status = 'pending_clarification') {
+  t.status = status;
+  t.claimed_by = null;
+  return t;
+}
+
+async function run() {
+  let passed = 0;
+  const test = (name, fn) => {
+    try {
+      fn();
+      console.log(`  ok ${name}`);
+      passed++;
+    } catch (e) {
+      console.error(`  FAIL ${name}:`, e.message);
+      process.exitCode = 1;
+    } finally {
+      process.env = { ...ORIG_ENV };
+    }
+  };
+
+  // ---- 1. PROPERTY: the cycle terminates -------------------------------------
+
+  test('a task that is always released stops being served after the cap', () => {
+    const t = task(435029);
+    const tasks = [t];
+    const max = A.maxTaskClaims();
+    let claims = 0;
+    // Bound the loop well above the cap so a broken cap shows up as a failed
+    // assertion rather than as a hanging test.
+    for (let i = 0; i < max * 10; i++) {
+      const got = A.selectClaimableTask(tasks, { agentName: `agent-${i % 11}`, maxClaims: max });
+      if (!got) break;
+      claims++;
+      releaseToPool(got);
+    }
+    assert.equal(claims, max, `expected exactly ${max} claims before exhaustion, got ${claims}`);
+    assert.equal(A.selectClaimableTask(tasks, { agentName: 'agent-fresh' }), null,
+      'an exhausted task must not be served to a fresh agent either');
+  });
+
+  test('the cap is global, not per-agent — 11 agents share one budget', () => {
+    // This is the specific thing the in-memory claimHistory could not do: each of
+    // the 11 live agents had its own Map, so each got its own private budget.
+    const t = task(1);
+    const tasks = [t];
+    const agents = Array.from({ length: 11 }, (_, i) => `trinity-${i}`);
+    let claims = 0;
+    for (let i = 0; i < 200; i++) {
+      const got = A.selectClaimableTask(tasks, { agentName: agents[i % agents.length] });
+      if (!got) break;
+      claims++;
+      releaseToPool(got);
+    }
+    assert.equal(claims, A.maxTaskClaims());
+  });
+
+  test('release via plain pending is capped too, not just pending_clarification', () => {
+    // releaseTask() -> 'pending' and the exception path -> 'pending' are separate
+    // release paths. Counting at CLAIM time is what makes the cap cover all of them.
+    const t = task(2);
+    const tasks = [t];
+    let claims = 0;
+    for (let i = 0; i < 100; i++) {
+      const got = A.selectClaimableTask(tasks, { agentName: 'a' });
+      if (!got) break;
+      claims++;
+      releaseToPool(got, 'pending');
+    }
+    assert.equal(claims, A.maxTaskClaims());
+  });
+
+  test('claim_count increments by exactly one per claim', () => {
+    const t = task(3);
+    A.selectClaimableTask([t], { agentName: 'a' });
+    assert.equal(t.claim_count, 1);
+    releaseToPool(t);
+    A.selectClaimableTask([t], { agentName: 'b' });
+    assert.equal(t.claim_count, 2);
+  });
+
+  test('a task at claim_count === max is already exhausted (boundary is exclusive)', () => {
+    const max = A.maxTaskClaims();
+    assert.equal(A.selectClaimableTask([task(4, { claim_count: max })], { agentName: 'a' }), null);
+    assert.ok(A.selectClaimableTask([task(5, { claim_count: max - 1 })], { agentName: 'a' }),
+      'one claim below the cap must still be servable');
+  });
+
+  test('a NULL claim_count (pre-migration row) is treated as 0, not as exhausted', () => {
+    // Every row that existed before the column was added reads as 0 via the DEFAULT,
+    // but COALESCE is what keeps an explicit NULL from silently parking a task forever.
+    const t = task(6, { claim_count: null });
+    const got = A.selectClaimableTask([t], { agentName: 'a' });
+    assert.ok(got, 'a row with no claim_count must remain claimable');
+    assert.equal(got.claim_count, 1);
+  });
+
+  test('the cap does not disturb the existing selector predicates', () => {
+    const fresh = () => [
+      task(10, { status: 'done' }),                        // wrong status
+      task(11, { claimed_by: 'someone-else' }),            // already claimed
+      task(12, { assigned_to: 'other-agent' }),            // assigned elsewhere
+      task(13),                                            // <- the only claimable one
+    ];
+    const got = A.selectClaimableTask(fresh(), { agentName: 'me' });
+    assert.ok(got);
+    assert.equal(got.id, 13);
+    // blacklist still excludes
+    assert.equal(A.selectClaimableTask(fresh(), { agentName: 'me', blacklist: [13] }), null);
+  });
+
+  test('priority DESC, created_at ASC ordering still decides which task is served', () => {
+    const tasks = [
+      task(20, { priority: 1, created_at: '2026-07-27T00:00:00Z' }),
+      task(21, { priority: 9, created_at: '2026-07-27T05:00:00Z' }),
+      task(22, { priority: 9, created_at: '2026-07-27T01:00:00Z' }),
+    ];
+    assert.equal(A.selectClaimableTask(tasks, { agentName: 'me' }).id, 22);
+  });
+
+  test('MAX_TASK_CLAIMS is env-tunable without a deploy, and rejects junk', () => {
+    process.env.MAX_TASK_CLAIMS = '3';
+    assert.equal(A.maxTaskClaims(), 3);
+    process.env.MAX_TASK_CLAIMS = 'not-a-number';
+    assert.equal(A.maxTaskClaims(), A.DEFAULT_MAX_TASK_CLAIMS);
+    process.env.MAX_TASK_CLAIMS = '0';
+    assert.equal(A.maxTaskClaims(), A.DEFAULT_MAX_TASK_CLAIMS, '0 would park every task — must fall back');
+    process.env.MAX_TASK_CLAIMS = '-5';
+    assert.equal(A.maxTaskClaims(), A.DEFAULT_MAX_TASK_CLAIMS);
+  });
+
+  // ---- 2. WIRING: the live SQL carries the same guards ------------------------
+  // These are what stop the mirror above from drifting into a self-satisfying oracle.
+
+  test('CLAIM_SQL increments claim_count in the same statement that claims', () => {
+    const sql = A.CLAIM_SQL.replace(/\s+/g, ' ');
+    assert.match(sql, /SET .*claim_count = COALESCE\(claim_count, ?0\) \+ 1/,
+      'the increment must be in the claiming UPDATE — a separate write reopens the race');
+  });
+
+  test('CLAIM_SQL refuses to select a task at or above the cap', () => {
+    const sql = A.CLAIM_SQL.replace(/\s+/g, ' ');
+    assert.match(sql, /AND COALESCE\(claim_count, ?0\) < \$6/,
+      'the cap predicate is the whole fix; without it claim_count is just telemetry');
+  });
+
+  test('CLAIM_SQL still carries the race-safety guards it had before', () => {
+    const sql = A.CLAIM_SQL.replace(/\s+/g, ' ');
+    for (const guard of ['FOR UPDATE SKIP LOCKED', 'LIMIT 1', 'claimed_by IS NULL',
+      'ORDER BY priority DESC, created_at ASC']) {
+      assert.ok(sql.includes(guard), `lost pre-existing guard: ${guard}`);
+    }
+    assert.ok(!/SELECT \*/.test(sql), 'SELECT * would reintroduce the 2026-06-19 egress bug');
+  });
+
+  test('CLAIM_SQL returns claim_count so callers can see how contested a task is', () => {
+    assert.match(A.CLAIM_SQL.replace(/\s+/g, ' '), /RETURNING [^)]*claim_count/);
+  });
+
+  test('every $N placeholder in CLAIM_SQL is actually bound by buildClaimParams', () => {
+    // Regression for mutation M12, which SURVIVED the first version of this suite: the SQL
+    // asserted the cap while the call site quietly stopped passing it. That is not a degraded
+    // cap — Postgres rejects the statement, getNextTask() catches and returns null, and the whole
+    // fleet goes idle looking exactly like an empty queue. String assertions on the SQL alone
+    // cannot see it; only comparing the SQL against the real bind list can.
+    const highest = Math.max(...[...A.CLAIM_SQL.matchAll(/\$(\d+)/g)].map((m) => Number(m[1])));
+    const params = A.buildClaimParams('trinity-test', new Date().toISOString(), [], null);
+    assert.equal(params.length, highest,
+      `CLAIM_SQL binds up to $${highest} but buildClaimParams supplies ${params.length}`);
+    assert.equal(params[highest - 1], A.maxTaskClaims(), 'the cap must be the last bind');
+    assert.ok(params.every((p) => p !== undefined), 'an undefined bind is a runtime query error');
+  });
+
+  test('the mirror and the SQL agree on the claimable status set', () => {
+    // pending_clarification is claimable BY DESIGN (#25). Recorded here so that if
+    // someone removes it, they do it deliberately and see this test.
+    assert.deepEqual(A.CLAIMABLE_STATUSES, ['pending', 'todo', 'assigned', 'pending_clarification']);
+  });
+
+  console.log(`\nclaimCap.test.js: ${passed} passed`);
+  if (process.exitCode) console.error('claimCap.test.js: FAILURES ABOVE');
+}
+
+run();


### PR DESCRIPTION
## What this fixes

Task `435029` was claimed **365 times** and produced **239 artifacts** from **11 distinct agents** in ~1h40m — roughly one LLM call every 25 seconds — before stopping by luck. [V sql:2026-07-27]

## The prior diagnosis was wrong, and that matters

Earlier build-loop beats attributed this to a "blind UPDATE claim race" in this repo. **Reading the actual query refutes that.** The claim has been a single-row atomic `UPDATE ... WHERE id = (SELECT ... FOR UPDATE SKIP LOCKED)` since the 2026-06-19 egress fix, with `claimed_by IS NULL` in the predicate. It is race-safe and was never the problem.

## The real defect: unbounded re-claim

Several paths legitimately return a task to a **claimable** status with `claimed_by=NULL`:

| path | resulting status | claimable? |
|---|---|---|
| `releaseTask()` — understand-fail, capability-gap | `pending` | yes |
| `processTask` exception path | `pending` | yes |
| escalation path (`task_escalated`) | `pending_clarification` | **yes, by design (#25)** |

The only brake was `this.claimHistory` — an **in-memory Map**. So it is lost on restart, it is **per-agent-process** (11 agents each had a private budget of `MAX_CLAIM_RETRIES=3`), and it is **never incremented on the escalation path at all**.

Log trail on 435029: `task_processing` ×365, `task_escalated` ×11, `substance_gate_degraded` ×256, `substance_gate_shadow_reject` ×5. It terminated only when a gate event finally recorded and moved the task to a terminal status.

Worth noting on its own: because `pending_clarification` is claimable, "escalate to a human for clarification" is currently converted into "hand it to another agent, forever." The cap bounds that; whether escalated tasks should be re-served at all is a separate design call.

## The fix

Count claims **durably, in the claim statement itself**, and refuse to serve a task past the cap.

Counting at **claim** time rather than at release time is what makes this total: it bounds every release path that exists today and every one added later, without enumerating them. The increment shares the statement that claims, so it is exact under concurrency for the same reason the claim is — no read-modify-write window.

- `trinity_tasks.claim_count` — migration included
- `CLAIM_SQL` / `buildClaimParams` / `CLAIMABLE_STATUSES` / `maxTaskClaims()` hoisted as statics, following the existing `isDeliverableTask` idiom, so the guards are testable without a DB
- `MAX_TASK_CLAIMS` env-tunable, default **12** (well above legitimate retries, far below 365)
- `tests/claimCap.test.js` — 15 tests, wired into CI

An exhausted task stays `pending` but stops being served: **parked, not lost**. The escalation/HITL rows these cycles already generate are how a human finds it.

## ⚠ Deploy ordering — the column must exist first

**The migration is ALREADY APPLIED to production** (`qnnpjhlxljtqyigedwkb`, 2026-07-27, additive, metadata-only on PG11+, verified present). That ordering is deliberate: if this code reached production before the column, the claim query would fail with `42703`, `getNextTask()` would catch it and return `null`, and **every agent would go quietly idle — an outage indistinguishable from an empty queue.** Column first, code second. Verified applied before this branch was pushed.

## Verification

- `node -c lib/ConstitutionalAgentV4.js` clean
- All 5 CI test files pass, including the 4 pre-existing ones (no regression)
- `tests/claimCap.test.js`: **15 passed**
- **The test suite was itself mutation-tested: 12 valid mutations, all killed.** Each mutation was confirmed landed by diff before any conclusion was drawn; originals were kept outside the repo and restored by copy, with zero residue confirmed by diff.
- **One mutation SURVIVED the first version of the suite and was a real hole:** dropping the cap bind from the call site. The SQL asserted the cap while the call site silently stopped passing it — not a degraded cap but a fleet-wide outage. `buildClaimParams` plus a placeholder-vs-bind-count test close it. The mirror-vs-SQL split exists for the same reason: a pure mirror proves the *cycle terminates*, and separate assertions prove the *live SQL still carries the same guards*, so the two cannot drift into a self-satisfying oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)