### PR TITLE
fix(swarm): remove the wildcard allowlist — .up.railway.app is a PUBLIC SUFFIX

### DIFF
--- a/lib/swarm-toolbelt.js
+++ b/lib/swarm-toolbelt.js
@@ -57,24 +57,75 @@
 const ENABLED = process.env.SWARM_TOOLBELT === 'on';
 
 /**
- * Hosts a swarm agent may reach. Suffix-matched against the URL hostname.
+ * Hosts a swarm agent may reach. EXACT match only — no wildcards.
  *
- * Scoped to our own surfaces on purpose. The tasks that were being fabricated are
- * "is the engine up", "what does /stats say", "did that receipt settle" — all of
- * which live here. Arbitrary web reading is a separate decision with a separate
- * risk profile, and bundling it into this change would make the flip harder to
- * reason about than it needs to be.
+ * ════════════════════════════════════════════════════════════════════════════════
+ * WHY THE WILDCARD IS GONE  [V by execution 2026-08-05, same day it merged]
+ * ════════════════════════════════════════════════════════════════════════════════
+ * The first version of this list contained `.up.railway.app` as a suffix entry.
+ * That is a PUBLIC SUFFIX: anyone can open a free Railway account and deploy to
+ * `<whatever>.up.railway.app`. So one entry intended to mean "our services" in
+ * fact meant "any Railway customer's service, including one stood up specifically
+ * to receive this traffic."
+ *
+ * That is not a theoretical concern for a read-only tool. `http_get` puts the URL
+ * on the wire, so a prompt-injected agent could **exfiltrate** by encoding what it
+ * knows into a query string — `https://attacker.up.railway.app/?d=<contents>` —
+ * and could pull attacker-authored text straight into its own context. Read-only
+ * limits what it can WRITE to our systems; it does nothing about what it can SEND.
+ *
+ * Suffix matching is therefore removed outright rather than patched. Every entry
+ * is now a full hostname compared with `===`. Adding a service means adding a
+ * line, which is a deliberate act — and the cost of that friction is much lower
+ * than the cost of a wildcard whose blast radius depends on someone else's
+ * customer signup page.
+ *
+ * (`SWARM_TOOLBELT_HOSTS` still overrides the list; entries are validated below so
+ * an operator cannot silently reintroduce a wildcard.)
  */
-const ALLOWED_HOSTS = (process.env.SWARM_TOOLBELT_HOSTS ||
-  'repid-engine-production.up.railway.app,.up.railway.app,api.hyperdag.org,trustshell.dev,hyperdag.org,sepolia.basescan.org,base-sepolia.blockscout.com'
-).split(',').map((h) => h.trim().toLowerCase()).filter(Boolean);
+const DEFAULT_HOSTS = [
+  'repid-engine-production.up.railway.app',
+  'api.hyperdag.org',
+  'trustshell.dev',
+  'hyperdag.org',
+  'sepolia.basescan.org',
+  'base-sepolia.blockscout.com',
+];
+
+const ALLOWED_HOSTS = (process.env.SWARM_TOOLBELT_HOSTS || DEFAULT_HOSTS.join(','))
+  .split(',')
+  .map((h) => h.trim().toLowerCase())
+  .filter(Boolean)
+  // A leading dot is the wildcard syntax that caused this. Refuse it loudly at
+  // load rather than honour it — an operator adding `.up.railway.app` back to the
+  // env var must find out immediately, not after an exfiltration.
+  .filter((h) => {
+    if (h.startsWith('.') || h.includes('*')) {
+      console.error(
+        `[swarm-toolbelt] REFUSING wildcard allowlist entry "${h}". ` +
+        'Suffix entries admit every customer of a shared hosting domain. List full hostnames.',
+      );
+      return false;
+    }
+    return true;
+  });
 
 const MAX_BYTES = Number(process.env.SWARM_TOOLBELT_MAX_BYTES || 24_000);
 const TIMEOUT_MS = Number(process.env.SWARM_TOOLBELT_TIMEOUT_MS || 15_000);
 
+/**
+ * Exact hostname match, after normalising the two forms that are the SAME host to
+ * DNS but different strings to JavaScript: case, and the canonical trailing dot.
+ *
+ * Punycode and embedded credentials need no handling here because the caller
+ * derives the hostname from `new URL()`, which already normalises IDN to punycode
+ * and resolves `https://good.example@evil.com` to `evil.com` — verified, not
+ * assumed. This function is nonetheless total on its input: it is exported and
+ * tested directly, so it must not depend on its caller having done that.
+ */
 function hostAllowed(hostname) {
-  const h = String(hostname || '').toLowerCase();
-  return ALLOWED_HOSTS.some((a) => (a.startsWith('.') ? h.endsWith(a) : h === a));
+  const h = String(hostname || '').toLowerCase().replace(/\.+$/, '');
+  return ALLOWED_HOSTS.includes(h);
 }
 
 /**

--- a/tests/swarm-toolbelt.test.mjs
+++ b/tests/swarm-toolbelt.test.mjs
@@ -92,12 +92,42 @@ console.log('\nALLOWLIST — egress is scoped, not open');
 
 t('matches our hosts and rejects lookalikes', () => {
   assert.ok(belt.hostAllowed('repid-engine-production.up.railway.app'));
-  assert.ok(belt.hostAllowed('anything.up.railway.app'), 'suffix entries must match subdomains');
   assert.ok(!belt.hostAllowed('evil.com'));
-  // The attack this stops: a suffix entry like `.up.railway.app` must not be
-  // satisfied by an attacker-controlled domain that merely CONTAINS it.
-  assert.ok(!belt.hostAllowed('up.railway.app.evil.com'), 'suffix match must anchor at the END');
+  assert.ok(!belt.hostAllowed('up.railway.app.evil.com'));
   assert.ok(!belt.hostAllowed('notrepid-engine-production.up.railway.app.attacker.io'));
+});
+
+// THE REGRESSION THAT MATTERS. The shipped version allowlisted `.up.railway.app`
+// as a suffix. That is a PUBLIC SUFFIX — anyone can deploy to it — so one entry
+// meaning "our services" actually meant "any Railway customer's service". Caught
+// the same day it merged, by running it rather than reading it.
+t('NO wildcard: a public-suffix sibling is refused', () => {
+  assert.ok(!belt.hostAllowed('attacker.up.railway.app'),
+    'ANY Railway customer can register this — it must never be reachable');
+  assert.ok(!belt.hostAllowed('totally-attacker-controlled.up.railway.app'));
+  // read-only does not mean harmless: http_get puts the URL on the wire, so a
+  // reachable attacker host is an EXFILTRATION channel via the query string.
+  assert.ok(!belt.hostAllowed('exfil.up.railway.app'));
+});
+
+t('same host, different string: case and trailing dot normalise', () => {
+  assert.ok(belt.hostAllowed('REPID-ENGINE-PRODUCTION.UP.RAILWAY.APP'), 'DNS is case-insensitive');
+  assert.ok(belt.hostAllowed('repid-engine-production.up.railway.app.'), 'canonical trailing dot is the same host');
+  // ...but normalising must not become a bypass.
+  assert.ok(!belt.hostAllowed('attacker.up.railway.app.'));
+});
+
+t('an operator cannot silently reintroduce a wildcard via the env var', () => {
+  // The entry is dropped at load with a loud console.error rather than honoured.
+  assert.ok(!belt.ALLOWED_HOSTS.some((h) => h.startsWith('.') || h.includes('*')),
+    'no wildcard may survive into the effective allowlist');
+});
+
+t('URL parsing resolves the two classic host-spoofing forms', () => {
+  // Not hostAllowed's job, but the caller depends on it, so pin the behaviour.
+  assert.equal(new URL('https://repid-engine-production.up.railway.app@evil.com/x').hostname, 'evil.com',
+    'credentials-before-@ must not be mistaken for the host');
+  assert.ok(new URL('https://exampIe.com/').hostname.length > 0);
 });
 
 t('is read-only — no tool can mutate anything', () => {


### PR DESCRIPTION
Found by execution the **same day #35 merged**, before the flag was ever turned on.

## The bug

The allowlist carried `.up.railway.app` as a **suffix** entry. That is a *public suffix* — anyone can open a free Railway account and deploy to `<whatever>.up.railway.app`. One line intended to mean *"our services"* actually meant *"any Railway customer's service, including one stood up specifically to receive this traffic."*

```
hostAllowed('attacker.up.railway.app')  ->  true      [V by execution]
```

## Why "read-only" did not save it

I argued #35 was safe partly because no tool can write. **That reasoning was incomplete.** `http_get` puts the URL *on the wire*, so a reachable attacker host is:

- an **exfiltration channel** — a prompt-injected agent encodes what it knows into a query string
- an **injection channel** — attacker-authored text flows straight into the agent's context

Read-only bounds what an agent can write to *us*. It says nothing about what it can *send*.

## Fix

Suffix matching **removed outright**, not patched. Every entry is a full hostname compared with `===`. Adding a service is now a deliberate line — that friction costs far less than a wildcard whose blast radius depends on someone else's signup page. A wildcard supplied via `SWARM_TOOLBELT_HOSTS` is dropped at load with a loud `console.error` so it cannot come back quietly.

`hostAllowed()` still normalises the two forms that are the same host to DNS but different strings to JS: **case** and the **canonical trailing dot**. Punycode and embedded credentials need no handling here because the caller derives the host from `new URL()` — verified, not assumed (`https://good@evil.com` → `evil.com`) — but the function is total on its input since it is exported and tested directly.

## Tests — mutations verified red

4 new assertions (**10 off / 14 on**). Both mutations confirmed RED before revert:

| mutation | observed |
|---|---|
| reinstate the wildcard | `AssertionError: ANY Railway customer can register this` |
| return a bare string on block | `AssertionError: must be an explicit failure` |

Green again after revert. Legit host still reachable `[V]`.

## Provenance — stated plainly

GA was dispatched to review #35 and returned "CONFIRMED" on this exact finding. **That confirmation is worthless and should not be cited.** Its own stderr shows it never read the file and never ran the tests (`read_file`/`grep` blocked — path outside workspace; `run_shell_command` unavailable), and I had named the hypothesis in the prompt, so it agreed with a premise I supplied.

This fix rests on execution I performed. The review is being fixed separately.