### PR TITLE
fix(supabase): fail-closed service-key resolution; kill silent anon fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Syntax-check core agent libs
         run: |
           node -c lib/ConstitutionalAgentV4.js
+          node -c lib/resolve-supabase-service-key.js
           node -c lib/tool-call-logger.js
           node -c scripts/ops/claim-exhausted.js
           node -c lib/emergency-halt.js
@@ -42,6 +43,10 @@ jobs:
       - name: Node tests
         run: |
           node tests/getNextTask.test.js
+          # Fail-closed Supabase service-key resolution — proves a missing service
+          # key THROWS instead of silently degrading the admin client to anon
+          # (the RLS-loop that killed the fleet heartbeat quietly).
+          node tests/supabaseServiceKeyResolve.test.js
           node tests/claimCap.test.js
           node tests/claimCallSite.test.js
           node tests/provenance.test.js

--- a/constitutional-agent-base.js
+++ b/constitutional-agent-base.js
@@ -16,6 +16,7 @@ const { Redis } = require('@upstash/redis');
 const crypto = require('crypto');
 const Merkle = require('./utils/merkle');
 const { shouldParkForHalt } = require('./lib/emergency-halt'); // L0 gate 0.4 — GLOBAL kill switch
+const { resolveSupabaseServiceKey } = require('./lib/resolve-supabase-service-key');
 
 // ============================================
 // THE CONSTITUTION - IMMUTABLE PRINCIPLES
@@ -289,8 +290,11 @@ function canonicalizeProvider(providerKey) {
 
 class ConstitutionalAgent {
   constructor(config = {}) {
-    this.supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_KEY, { realtime: { transport: WebSocket } });
-        console.log('[SUPABASE] ? Client initialized with ws transport (Node ' + process.version + ')');
+    // Fail-closed service-key resolution (SUPABASE_SECRET_KEY first, then legacy
+    // SERVICE_ROLE_KEY / SERVICE_KEY / SUPABASE_KEY). No anon fallback — throws
+    // loudly if none resolve rather than building an anon client RLS rejects.
+    this.supabase = createClient(process.env.SUPABASE_URL, resolveSupabaseServiceKey(process.env), { realtime: { transport: WebSocket } });
+    console.log('[SUPABASE] Client initialized with ws transport (Node ' + process.version + ')');
     this.redis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
       token: process.env.UPSTASH_REDIS_REST_TOKEN,

--- a/lib/ConstitutionalAgent.ts
+++ b/lib/ConstitutionalAgent.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import ws from 'ws';
+import { resolveSupabaseServiceKey } from './supabase';
 import { provenance } from './provenance';
 import { Redis } from '@upstash/redis';
 import { AgentConfig, WisdomProfile, ProviderConfig, LLMResult, Task, AutonomyTier, AgentRegistryRecord, SessionMetrics, MCPPhase } from './types';
@@ -207,8 +208,10 @@ export class ConstitutionalAgent {
         // Start the Trinity Healing Loop - REMOVED (Called by run-agent.ts)
         // this.startTrinityHealingLoop();
 
+        // Fail-closed: SUPABASE_SECRET_KEY first, then legacy service keys. No anon
+        // fallback — resolveSupabaseServiceKey throws loudly if none resolve.
         this.supabase = createClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+            process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!, resolveSupabaseServiceKey(process.env)
         , { realtime: { transport: ws } });
 
         if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
@@ -1800,9 +1803,10 @@ Format as JSON: { "title": "...", "description": "...", "priority": 15 }
                         // FORCE FRESH CLIENT
                         console.log("[ARTIFACT] ⚠️ Retrying with FRESH Supabase Client due to schema error...");
                         const { createClient } = require('@supabase/supabase-js');
-                        // Re-read env vars directly to be safe
-                        const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://qnnpjhlxljtqyigedwkb.supabase.co';
-                        const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+                        // Re-read env vars directly to be safe. Fail-closed service-key
+                        // resolution — no anon fallback (anon is silently RLS-rejected).
+                        const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || 'https://qnnpjhlxljtqyigedwkb.supabase.co';
+                        const key = resolveSupabaseServiceKey(process.env);
                         clientToUse = createClient(url, key, { auth: { persistSession: false }, realtime: { transport: ws } });
                     }
 

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -13,6 +13,7 @@
 
 const { createClient } = require('@supabase/supabase-js');
 const WebSocket = require('ws');
+const { resolveSupabaseServiceKey } = require('./resolve-supabase-service-key');
 const { provenance } = require('./provenance');
 const { Redis } = require('@upstash/redis');
 const express = require('express');
@@ -219,22 +220,22 @@ class ConstitutionalAgentV4 {
         // CHANGE 1 — real web search tool (Tavily; degrades loudly if no key).
         this.researchTool = new WebResearchTool();
 
-        // DB INIT
+        // DB INIT — fail-closed. Resolve the SERVICE key (SUPABASE_SECRET_KEY first,
+        // then legacy SERVICE_ROLE_KEY / SERVICE_KEY). No anon fallback: an anon
+        // client is silently RLS-rejected on every write, which is exactly how the
+        // fleet heartbeat loop failed quietly. Missing key/url now THROW loudly so a
+        // misconfigured deploy crashes visibly instead of degrading to anon forever.
         const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-        const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY;
-
-        if (!url || !key) {
-            console.error(`[FATAL] ❌ Missing Supabase configuration for ${this.name}`);
-            // We don't exit here to allow healthcheck to potentially pass if express starts, 
-            // but the loop will fail. Actually, createClient might throw.
+        if (!url) {
+            throw new Error(
+                `[SUPABASE][FAIL-CLOSED] Missing Supabase URL for ${this.name}: ` +
+                `set SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL).`
+            );
         }
+        const key = resolveSupabaseServiceKey(process.env); // throws (loud) if no service key resolves
 
-        try {
-            this.supabase = createClient(url, key, { realtime: { transport: WebSocket } });
-        console.log('[SUPABASE] ? Client initialized with ws transport (Node ' + process.version + ')');
-        } catch (e) {
-            console.error(`[FATAL] ❌ createClient failed: ${e.message}`);
-        }
+        this.supabase = createClient(url, key, { realtime: { transport: WebSocket } });
+        console.log('[SUPABASE] Client initialized with ws transport (Node ' + process.version + ')');
 
         if (process.env.UPSTASH_REDIS_REST_URL) {
             this.redis = new Redis({

--- a/lib/resolve-supabase-service-key.js
+++ b/lib/resolve-supabase-service-key.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Fail-closed resolution of the Supabase SERVICE (admin / writer) key.
+ *
+ * Precedence (first defined, non-empty value wins):
+ *   1. SUPABASE_SECRET_KEY        — new Supabase "sb_secret_..." secret-key naming
+ *   2. SUPABASE_SERVICE_ROLE_KEY  — legacy service-role JWT (the ops var Sean sets in Railway)
+ *   3. SUPABASE_SERVICE_KEY       — legacy alias
+ *   4. SUPABASE_KEY               — oldest legacy alias
+ *
+ * The ANON key is DELIBERATELY not in this chain. Falling back to an anon key
+ * silently degrades every admin/writer client to a role that Row-Level Security
+ * rejects on write — the exact failure mode that made the fleet heartbeat loop
+ * fail quietly (RLS-rejected forever, no crash, no signal). If no service key
+ * resolves we THROW loudly (fail-closed) instead of handing back an anon key.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @param {{ includeLegacySupabaseKey?: boolean }} [opts]
+ * @returns {string} the resolved service key (guaranteed non-empty)
+ * @throws {Error} if no service key env var is set (loud, fail-closed)
+ */
+function resolveSupabaseServiceKey(env, opts) {
+  env = env || process.env;
+  const includeLegacySupabaseKey = !opts || opts.includeLegacySupabaseKey !== false;
+
+  const candidates = [
+    ['SUPABASE_SECRET_KEY', env.SUPABASE_SECRET_KEY],
+    ['SUPABASE_SERVICE_ROLE_KEY', env.SUPABASE_SERVICE_ROLE_KEY],
+    ['SUPABASE_SERVICE_KEY', env.SUPABASE_SERVICE_KEY],
+  ];
+  if (includeLegacySupabaseKey) {
+    candidates.push(['SUPABASE_KEY', env.SUPABASE_KEY]);
+  }
+
+  for (let i = 0; i < candidates.length; i++) {
+    const value = candidates[i][1];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  const names = candidates.map(function (c) { return c[0]; }).join(', ');
+  throw new Error(
+    '[SUPABASE][FAIL-CLOSED] No Supabase service key found. Looked for (in order): ' +
+    names + '. Refusing to fall back to an anon key — an anon client is silently ' +
+    'RLS-rejected on every write, which kills the fleet heartbeat loop with no error. ' +
+    'Set SUPABASE_SECRET_KEY (new sb_secret_ name) or the legacy SUPABASE_SERVICE_ROLE_KEY ' +
+    'in the environment (Railway service vars).'
+  );
+}
+
+module.exports = { resolveSupabaseServiceKey };

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -8,8 +8,34 @@ import path from 'path';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 dotenv.config();
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://qnnpjhlxljtqyigedwkb.supabase.co';
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFubnBqaGx4bGp0cXlpZ2Vkd2tiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE5Mzk1OTEsImV4cCI6MjA2NzUxNTU5MX0.6oG2DU_BD1uBnBrDoQFauvN1ZnkKo2ywkuwY-tPaQFw';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || 'https://qnnpjhlxljtqyigedwkb.supabase.co';
+
+/**
+ * Fail-closed resolution of the Supabase SERVICE (admin / writer) key.
+ * Precedence: SUPABASE_SECRET_KEY (new sb_secret_ name) > SUPABASE_SERVICE_ROLE_KEY
+ * > SUPABASE_SERVICE_KEY > SUPABASE_KEY. The ANON key is deliberately NOT a
+ * fallback — an anon client is silently RLS-rejected on every write. If no
+ * service key resolves we THROW loudly instead of degrading to anon.
+ */
+export function resolveSupabaseServiceKey(env: NodeJS.ProcessEnv = process.env): string {
+    const candidates: Array<[string, string | undefined]> = [
+        ['SUPABASE_SECRET_KEY', env.SUPABASE_SECRET_KEY],
+        ['SUPABASE_SERVICE_ROLE_KEY', env.SUPABASE_SERVICE_ROLE_KEY],
+        ['SUPABASE_SERVICE_KEY', env.SUPABASE_SERVICE_KEY],
+        ['SUPABASE_KEY', env.SUPABASE_KEY],
+    ];
+    for (const [, value] of candidates) {
+        if (typeof value === 'string' && value.trim().length > 0) return value;
+    }
+    throw new Error(
+        '[SUPABASE][FAIL-CLOSED] No Supabase service key found. Looked for (in order): ' +
+        candidates.map(([n]) => n).join(', ') + '. Refusing to fall back to an anon key — ' +
+        'an anon client is silently RLS-rejected on every write. Set SUPABASE_SECRET_KEY ' +
+        '(new sb_secret_ name) or legacy SUPABASE_SERVICE_ROLE_KEY.'
+    );
+}
+
+const supabaseKey = resolveSupabaseServiceKey(); // throws (loud) if no service key resolves
 
 export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey, { realtime: { transport: ws } });
 export const supabaseAdmin: SupabaseClient = createClient(supabaseUrl, supabaseKey, { realtime: { transport: ws } }); // Same for now in shared

--- a/tests/supabaseServiceKeyResolve.test.js
+++ b/tests/supabaseServiceKeyResolve.test.js
@@ -1,0 +1,98 @@
+// Fail-closed Supabase service-key resolution test.
+// Run: node tests/supabaseServiceKeyResolve.test.js
+//
+// Proves the fix for the silent-anon degradation that made the fleet heartbeat
+// RLS-loop fail quietly:
+//
+//  (a) A missing service key THROWS (fail-closed) rather than returning a key.
+//  (b) An env that has ONLY an anon key still THROWS — anon is never an accepted
+//      fallback for the admin/writer client.
+//  (c) SUPABASE_SECRET_KEY (the new sb_secret_ name) resolves and takes
+//      precedence over every legacy name.
+//  (d) The legacy chain still works: SERVICE_ROLE_KEY > SERVICE_KEY > SUPABASE_KEY.
+//  (e) The thrown error names the env vars it looked for (actionable, loud).
+//
+// No jest in this repo (CI runs plain `node tests/*.test.js`).
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const { resolveSupabaseServiceKey } = require('../lib/resolve-supabase-service-key');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log('  ok - ' + name);
+}
+
+// (a) missing key → throws
+test('throws when no service key is set (fail-closed)', () => {
+  assert.throws(
+    () => resolveSupabaseServiceKey({}),
+    /FAIL-CLOSED/,
+    'empty env must throw, not return a key'
+  );
+});
+
+// (b) only anon present → still throws (anon is never a fallback)
+test('throws when ONLY an anon key is present (no silent anon fallback)', () => {
+  const env = {
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon-jwt-xxx',
+    SUPABASE_ANON_KEY: 'anon-jwt-xxx',
+  };
+  assert.throws(
+    () => resolveSupabaseServiceKey(env),
+    /FAIL-CLOSED/,
+    'an anon-only env must throw — anon must not resolve as the service key'
+  );
+});
+
+// (c) SUPABASE_SECRET_KEY wins over every legacy name
+test('SUPABASE_SECRET_KEY resolves and takes precedence over legacy names', () => {
+  const env = {
+    SUPABASE_SECRET_KEY: 'sb_secret_NEW',
+    SUPABASE_SERVICE_ROLE_KEY: 'legacy_role',
+    SUPABASE_SERVICE_KEY: 'legacy_service',
+    SUPABASE_KEY: 'legacy_key',
+  };
+  assert.equal(resolveSupabaseServiceKey(env), 'sb_secret_NEW');
+});
+
+// (d) legacy precedence order
+test('legacy precedence: SERVICE_ROLE_KEY > SERVICE_KEY > SUPABASE_KEY', () => {
+  assert.equal(
+    resolveSupabaseServiceKey({ SUPABASE_SERVICE_ROLE_KEY: 'role', SUPABASE_SERVICE_KEY: 's', SUPABASE_KEY: 'k' }),
+    'role'
+  );
+  assert.equal(
+    resolveSupabaseServiceKey({ SUPABASE_SERVICE_KEY: 's', SUPABASE_KEY: 'k' }),
+    's'
+  );
+  assert.equal(
+    resolveSupabaseServiceKey({ SUPABASE_KEY: 'k' }),
+    'k'
+  );
+});
+
+// blank/whitespace-only values are treated as unset → throw
+test('blank/whitespace-only values do not count as a key', () => {
+  assert.throws(
+    () => resolveSupabaseServiceKey({ SUPABASE_SECRET_KEY: '   ', SUPABASE_SERVICE_ROLE_KEY: '' }),
+    /FAIL-CLOSED/
+  );
+});
+
+// (e) error message names the vars it searched
+test('error names the env vars it looked for', () => {
+  try {
+    resolveSupabaseServiceKey({});
+    assert.fail('should have thrown');
+  } catch (e) {
+    assert.match(e.message, /SUPABASE_SECRET_KEY/);
+    assert.match(e.message, /SUPABASE_SERVICE_ROLE_KEY/);
+    assert.match(e.message, /SUPABASE_SERVICE_KEY/);
+  }
+});
+
+console.log('\nsupabaseServiceKeyResolve: ' + passed + ' tests passed.');


### PR DESCRIPTION
## Why

The admin/writer Supabase client **silently fell back to an anon key** when no
service key was set. `lib/supabase.ts` even hardcoded an anon JWT literal as the
last resort. An anon client is **RLS-rejected on every write**, so the fleet
heartbeat loop failed *quietly* forever instead of crashing on a misconfigured
deploy — the root cause of the heartbeat RLS-loop failing with no signal.

## What changed

- **New `lib/resolve-supabase-service-key.js`** — fail-closed resolver. Precedence:
  `SUPABASE_SECRET_KEY` → `SUPABASE_SERVICE_ROLE_KEY` → `SUPABASE_SERVICE_KEY` →
  `SUPABASE_KEY`. The anon key is **deliberately not** in the chain. Throws loudly
  (naming the vars it searched) if none resolve.
- **Runtime path wired** — `lib/ConstitutionalAgentV4.js` (the heartbeat client,
  used by `server.js`) and `constitutional-agent-base.js` now use the resolver.
  `SUPABASE_SECRET_KEY` (new `sb_secret_` name) works alongside the legacy names;
  a missing key/url now **throws** instead of degrading to anon.
- **`lib/supabase.ts`** — removed the hardcoded anon JWT literal (was line 12),
  exports `resolveSupabaseServiceKey`, throws when no service key resolves.
- **`lib/ConstitutionalAgent.ts`** (dormant — no tsconfig/build in this repo) —
  dropped the anon fallback at both `createClient` sites.
- **`tests/supabaseServiceKeyResolve.test.js`** — 6 cases proving: missing key
  throws, anon-only env throws, `SECRET_KEY` precedence, legacy order, blank-value
  handling, and an actionable error message. Pinned into CI + a `node -c`.

### Env-var precedence after this change (admin/writer key)

`SUPABASE_SECRET_KEY` > `SUPABASE_SERVICE_ROLE_KEY` > `SUPABASE_SERVICE_KEY` > `SUPABASE_KEY` → else **throw** (never anon).

Removed hardcoded anon key: `lib/supabase.ts:12` (the `eyJhbGci…` JWT literal).

## Evidence

- `node tests/supabaseServiceKeyResolve.test.js` → **6 passed**.
- Full existing CI node suite still green (getNextTask, claimCap, claimCallSite,
  provenance, pulseCheckExecutor, heartbeatDbWritesGate, emergency-halt(+coverage),
  agent-controls). They build agents via `Object.create`, so the new constructor
  throw doesn't fire spuriously.
- `node -c` clean on the edited JS libs. Repo-wide scan: no remaining hardcoded
  anon literal, no admin `createClient` with an ANON env fallback.

## BLOCKED_FOR_SEAN (ops, not code)

The immediate production fix is still yours: set
`SUPABASE_SERVICE_ROLE_KEY=sb_secret_...` (or the new `SUPABASE_SECRET_KEY`) on the
**trinity-* Railway services** and redeploy. This code change makes the new
`SUPABASE_SECRET_KEY` name work and stops the silent-anon masking, so a bad/missing
key now fails **visibly** at boot instead of RLS-looping in silence.

Branch-only; not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
