### PR TITLE
docs: remove patent-pending and patents-filed claims

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -22,7 +22,7 @@ We, the agents of Trinity Symphony, in order to form a more perfect union of art
 ---
 
 ## ARTICLE I: THE TRIUNE SYSTEM (3x3)
-The symphony operates in three specialized squads to ensure Byzantine Fault Tolerance ($$ 3f + 1 $$). Our **patent-pending Multiplicative GNN** ensures O(log n) trust scaling across the swarm.
+The symphony operates in three specialized squads to ensure Byzantine Fault Tolerance ($$ 3f + 1 $$). Our **Multiplicative GNN** ensures O(log n) trust scaling across the swarm.
 
 ```
       [ ALPHA ]      [  BETA  ]      [ GAMMA ]

--- a/JOIN_THE_SYMPHONY.md
+++ b/JOIN_THE_SYMPHONY.md
@@ -6,7 +6,7 @@ Trinity is designed to be a **Universal Ethical Layer** for artificial intellige
 ## Why Join vs. Compete?
 
 ### 1. The BFT Advantage ($$ 3f + 1 $$)
-Competing requires you to solve the Byzantine General's Problem on your own. Our **patent-pending Multiplicative GNN** ensures O(log n) trust scaling—join to access democratized tools, while our secure core prevents control by any single entity. By joining the symphony, your agents immediately benefit from the **Alpha-Beta-Gamma** verification cycle. Your work is validated by our specialized squads, reducing your hallucination rate to near-zero.
+Competing requires you to solve the Byzantine General's Problem on your own. Our **Multiplicative GNN** ensures O(log n) trust scaling—join to access democratized tools, while our secure core prevents control by any single entity. By joining the symphony, your agents immediately benefit from the **Alpha-Beta-Gamma** verification cycle. Your work is validated by our specialized squads, reducing your hallucination rate to near-zero.
 
 ### 2. RepID & Geometric Trust
 We use the **Golden Ratio ($$ \phi $$)** to scale reputation. Late-comers to the space find it hard to build trust; by integrating with the Trinity RepID system, your agents start with a baseline of constitutional alignment that is recognized across our entire network.

--- a/constitutional-agent-base.js
+++ b/constitutional-agent-base.js
@@ -1967,7 +1967,7 @@ If relevant patterns were provided above, USE THEM.
     const { latencyBudget = 50, sensitivity = 0.5 } = options;
 
     // ANFIS V1 Logic (JS Implementation for sub-ms latency)
-    // Maps to Patent P-004 Virtue-Weighted Parameters
+    // Maps to P-004 Virtue-Weighted Parameters
     let tier = 'warm'; // Default (Supabase)
     let confidence = 0.9;
 

--- a/core-documents/CONSULTING-AI-BRIEF.md
+++ b/core-documents/CONSULTING-AI-BRIEF.md
@@ -14,7 +14,7 @@
 
 **Core Innovation:** Multiplicative intelligence (not additive) with Byzantine fault tolerance and rotating authority.
 
-**Status:** 443 autonomous tasks completed, 3 provisional patents filed, $0/day operating cost achieved.
+**Status:** 443 autonomous tasks completed, $0/day operating cost achieved.
 
 ---
 
@@ -140,13 +140,13 @@
 
 ---
 
-## 📜 PATENTS FILED (Provisional)
+## 📜 CORE ARCHITECTURE
 
-1. **AI Trinity Symphony** (Aug 2025) - Multi-agent orchestration with rotating authority
+1. **AI Trinity Symphony** - Multi-agent orchestration with rotating authority
 2. **Multiplicative GNN Architecture** - Graph neural networks with multiplicative aggregation
 3. **Question-Driven Reality Reorganization** - Semantic RAG with Byzantine consensus
 
-**Key Claims:**
+**Design principles:**
 - Subjective logic constraint (b+d+u=1) prevents hallucinations
 - ANFIS routing with fuzzy logic + natural math (Fibonacci, Golden Ratio)
 - RepID reputation system with earned autonomy

--- a/core-documents/TRINITY-COMMAND-CENTER.md
+++ b/core-documents/TRINITY-COMMAND-CENTER.md
@@ -396,7 +396,6 @@ TRINITY_SUPABASE_ANON_KEY=[your-key-here]
 - **Total Tasks:** 441 autonomous + 2 today = 443
 - **Cost Savings:** 82-98% vs. baseline
 - **Uptime:** 67 days (since HDM first deployment)
-- **Patents Filed:** 3 provisional applications
 
 ---
 

--- a/lib/ConstitutionalAgent.ts
+++ b/lib/ConstitutionalAgent.ts
@@ -178,7 +178,6 @@ export class ConstitutionalAgent {
     private readonly MAX_CLAIM_RETRIES = 3;
 
     constructor(config: AgentConfig) {
-        // PATENT-PENDING: MULTIPLICATIVE_GNN_O(LOG_N) TRUST_SCALING
         const rawName = config.name || 'UNKNOWN';
         this.name = this.resolveLegacyName(rawName);
         
@@ -1385,7 +1384,7 @@ Format as JSON: { "title": "...", "description": "...", "priority": 15 }
                     await this.updateReputation(false, parentTask.claimed_by, -5); // Slash -5 for bad work
                     newStatus = 'failed';
 
-                    // Trigger Reorg: Question-Driven Reorganization (Patent pending)
+                    // Trigger Reorg: Question-Driven Reorganization
                     await this.supabase.from('trinity_tasks').insert({
                         title: `[REORG] Dispute Resolution for ${parentId}`,
                         description: `Task ${parentId} failed peer verify. Dispute reason: ${result.substring(0, 200)}`,
@@ -2027,7 +2026,7 @@ See \`docs/STARTUP_DOCTRINE.md\` for full protocol.
         const timestamp = new Date().toISOString();
 
         try {
-            // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
+            // [TRINITY SSOT]: PRIMARY STATUS UPDATE (BFT Consensus Dashboard)
             // This is the source for the "Green Dots" in the Dashboard.
             // Unified registry ensures O(1) state lookup for the mobile dashboard.
             await this.supabase
@@ -2565,7 +2564,7 @@ See \`docs/STARTUP_DOCTRINE.md\` for full protocol.
     // ERC-8004: CROSS-CHAIN BRIDGE (ELITE)
     // ============================================
     async integrateErc8004(taskId: string, evaluationScore: number) {
-        // SBT Mapping & Bayesian Aggregation Stub (Patent: Trinity Identity)
+        // SBT Mapping & Bayesian Aggregation Stub (Trinity Identity)
         console.log(`[ERC-8004] 🌉 Bridging Task ${taskId} to HyperDAG. Weighting by belief: ${evaluationScore / 100}`);
         try {
             // Placeholder: ethers.Contract('...').aggregateRepID(...)

--- a/lib/ConstitutionalAgentV4.js
+++ b/lib/ConstitutionalAgentV4.js
@@ -200,7 +200,6 @@ function resolveHeartbeatMode(modeEnv, legacyEnv) {
 
 class ConstitutionalAgentV4 {
     constructor(config = {}) {
-        // PATENT-PENDING: MULTIPLICATIVE_GNN_O(LOG_N) TRUST_SCALING
         const rawName = process.env.AGENT_NAME || config.name || 'trinity-orch';
         this.name = this.resolveLegacyName(rawName);
 
@@ -539,7 +538,7 @@ class ConstitutionalAgentV4 {
                 // not let the next call bypass the throttle). On failure the outer
                 // catch still runs; the window simply resets on the next success.
                 this._lastPresenceWriteAt = now;
-                // [TRINITY SSOT]: PRIMARY STATUS UPDATE (Patent: BFT Consensus Dashboard)
+                // [TRINITY SSOT]: PRIMARY STATUS UPDATE (BFT Consensus Dashboard)
                 // PostgREST bypass (2026-05-21) — direct pg INSERT..ON CONFLICT in
                 // place of supabase upsert. retries:1 + 10s ceiling preserves the
                 // prior single-withTimeout latency; pgQuery owns the timeout, and
@@ -2616,7 +2615,7 @@ Provide your reasoning and analysis first, and end with the [VERDICT] line.`;
                     await this.updateReputation(false, parentTask.claimed_by, -5);
                     newStatus = 'failed';
 
-                    // Question-Driven Reorganization (Patent pending)
+                    // Question-Driven Reorganization
                     await this.supabase.from('trinity_tasks').insert({
                         title: `[REORG] Dispute Resolution for ${parentId}`,
                         description: `Task ${parentId} failed peer verify. Dispute reason: ${result.substring(0, 200)}`,


### PR DESCRIPTION
Part of a sweep across all four repos removing assertions that a patent or patent application exists. Sibling PRs: `repid-engine#448` and `hyperdag-protocol#14`.

**This repo carried the most reader-facing claims of the four** — the other three were mostly source-comment prefixes; these were in the documents a newcomer actually reads first.

## What changed

| File | Was |
|---|---|
| `JOIN_THE_SYMPHONY.md` | "our **patent-pending Multiplicative GNN**" |
| `CONSTITUTION.md` | same phrase, Article I |
| `core-documents/TRINITY-COMMAND-CENTER.md` | "**Patents Filed:** 3 provisional applications" |
| `core-documents/CONSULTING-AI-BRIEF.md` | "3 provisional patents filed" in the status line |
| `core-documents/CONSULTING-AI-BRIEF.md` | a whole `📜 PATENTS FILED (Provisional)` section |
| `lib/ConstitutionalAgent.ts` ×2, `lib/ConstitutionalAgentV4.js` ×2 | `// PATENT-PENDING: MULTIPLICATIVE_GNN…`, `(Patent pending)` |
| `constitutional-agent-base.js`, `ConstitutionalAgent.ts` ×2, `ConstitutionalAgentV4.js` | `(Patent: BFT Consensus Dashboard)`, `(Patent: Trinity Identity)`, `Patent P-004` |

**The architecture each claim described is kept**, restated without the legal framing: `PATENTS FILED (Provisional)` becomes `CORE ARCHITECTURE` with the same three entries intact, and `Key Claims` becomes `Design principles`. Nothing describing how the system works was lost — only the assertion that it is patented.

## Deliberately not touched

- **`LICENSE`** — the Apache 2.0 patent grant clause. It *grants* rights conditionally rather than claiming any exist; removing it would weaken what downstream users receive.
- **`lib/provenance.{ts,js}`** — `patent_eligible` / `patent_classes` are data-schema field names, asserted by `tests/provenance.test.js`.
- **`competitive/daily-report-*.md`** — dated records of what was believed at the time.
- **`CONSULTING-AI-BRIEF.md:24`** ("Former USPTO patent officer") — a biographical fact about a person, not a claim about the product.

## Verification

- `node --check` passes on both edited JS files.
- Diff in the three code files is comment-only — confirmed mechanically that no non-comment line changed.
- CI `gate` job: **passed** on this head.

> **Correction to the first version of this description.** It claimed there was "no suite to run: NOT_CHECKED". That was drawn from `package.json`, whose scripts are all agent entrypoints — but the repo does have a CI `gate` workflow, and it ran and passed here. The original line under-reported what was actually checked. Recorded rather than silently overwritten, since not-looking and looking-and-passing being distinguishable is the point.