### PR TITLE
agent-controls: circuit-break the dead Upstash Redis endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
           # this list — a test that never runs proves nothing. Added because it
           # covers the sibling lever the halt composes with.
           node tests/agent-controls.test.js
+          # Redis circuit breaker for the Upstash-backed control cache — pins
+          # that a dead UPSTASH_REDIS_REST_URL degrades to one warning burst
+          # plus a cooldown instead of a failing call (and a log line) forever,
+          # and that a recovered endpoint is used again once the cooldown ends.
+          node tests/agentControlsRedisBreaker.test.js
           # Survivor liveness. Pins that the group watchdog reads a signal that is
           # actually written, that absence is never reported as death, and that
           # "every peer is dead" indicts the sensor rather than the peers. The

--- a/lib/agent-controls.js
+++ b/lib/agent-controls.js
@@ -2,6 +2,21 @@
  * Agent loop control — reads `agent_controls.enabled` (live SSOT table).
  * Cache: Upstash Redis (10s TTL) + in-process fallback.
  * Default-off when the control store is unreachable (CLAUDE-RULE-8 safe mode).
+ *
+ * CIRCUIT BREAKER (added 2026-08-26): every deployed agent service
+ * (trinity-gcm, trinity-sophia, trinity-hdm, trinity-torch, trinity-veritas —
+ * observed directly in their Railway deploy logs) was logging "redis cache
+ * read/write failed: fetch failed" on an unbroken loop for days.
+ * `UPSTASH_REDIS_REST_URL` is set — otherwise getRedis() would return null
+ * before ever calling the API and no warning would print at all — but the
+ * endpoint it points to is unreachable. The memCache + DB fallback below
+ * already keeps `isAgentEnabled` correct through that (this was never a
+ * correctness bug), but every single call was still paying a live network
+ * round-trip to a known-dead host and logging a warning for it, forever.
+ * Past FAILURE_THRESHOLD consecutive failures this stops calling Upstash for
+ * COOLDOWN_MS and logs the open/close transition once instead of on every
+ * call. A live Upstash endpoint never sees a failure, so the breaker never
+ * opens for it.
  */
 const { pgQuery } = require('./direct-pg');
 const { Redis } = require('@upstash/redis');
@@ -11,8 +26,41 @@ const memCache = new Map();
 
 let redisClient = null;
 
+const FAILURE_THRESHOLD = 3;
+const COOLDOWN_MS = Number(process.env.AGENT_CONTROL_REDIS_COOLDOWN_MS || 5 * 60 * 1000);
+let consecutiveFailures = 0;
+let openUntil = 0;
+
+function redisBreakerOpen() {
+  return openUntil > Date.now();
+}
+
+function recordRedisFailure(op, message) {
+  consecutiveFailures += 1;
+  if (consecutiveFailures === FAILURE_THRESHOLD) {
+    openUntil = Date.now() + COOLDOWN_MS;
+    console.warn(
+      `[agent-controls] redis cache ${op} failed ${FAILURE_THRESHOLD}x in a row (${message}) — ` +
+        `opening circuit breaker for ${Math.round(COOLDOWN_MS / 1000)}s (DB + in-process cache still serve requests)`
+    );
+  } else {
+    // Log the first couple of failures individually — enough to diagnose a
+    // real blip without repeating forever once the breaker takes over.
+    console.warn(`[agent-controls] redis cache ${op} failed:`, message);
+  }
+}
+
+function recordRedisSuccess() {
+  if (consecutiveFailures > 0 || openUntil > 0) {
+    console.warn('[agent-controls] redis cache recovered — closing circuit breaker');
+  }
+  consecutiveFailures = 0;
+  openUntil = 0;
+}
+
 function getRedis() {
   if (!process.env.UPSTASH_REDIS_REST_URL) return null;
+  if (redisBreakerOpen()) return null;
   if (!redisClient) {
     redisClient = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
@@ -43,8 +91,9 @@ async function setRemoteCache(key, enabled) {
   if (!redis) return;
   try {
     await redis.set(key, enabled ? '1' : '0', { ex: CACHE_TTL_SEC });
+    recordRedisSuccess();
   } catch (e) {
-    console.warn('[agent-controls] redis cache write failed:', e.message);
+    recordRedisFailure('write', e.message);
   }
 }
 
@@ -53,11 +102,12 @@ async function readRemoteCache(key) {
   if (!redis) return null;
   try {
     const v = await redis.get(key);
+    recordRedisSuccess();
     if (v === '1' || v === true) return true;
     if (v === '0' || v === false) return false;
     return null;
   } catch (e) {
-    console.warn('[agent-controls] redis cache read failed:', e.message);
+    recordRedisFailure('read', e.message);
     return null;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "trinity-symphony-shared",
       "version": "7.2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.105.4",
         "@upstash/redis": "^1.28.0",

--- a/tests/agentControlsRedisBreaker.test.js
+++ b/tests/agentControlsRedisBreaker.test.js
@@ -1,0 +1,104 @@
+// node tests/agentControlsRedisBreaker.test.js
+//
+// Every deployed agent service (trinity-gcm, trinity-sophia, trinity-hdm,
+// trinity-torch, trinity-veritas) was observed logging "redis cache
+// read/write failed: fetch failed" on an unbroken loop for days against a
+// dead UPSTASH_REDIS_REST_URL. This proves the fix: after FAILURE_THRESHOLD
+// consecutive failures, agent-controls.isAgentEnabled() stops calling
+// Upstash for a cooldown window instead of retrying (and logging) on every
+// single call, while still returning the correct answer throughout via the
+// existing DB + in-process cache fallback.
+//
+// Stubs ./direct-pg and @upstash/redis in the require cache before
+// requiring the module under test, mirroring tests/heartbeatDbWritesGate.test.js.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+
+process.env.UPSTASH_REDIS_REST_URL = 'http://upstash.invalid';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+process.env.AGENT_CONTROL_REDIS_COOLDOWN_MS = '120'; // short, so the test can wait it out for real
+process.env.AGENT_CONTROL_CACHE_TTL_SEC = '9999'; // keep memCache from expiring mid-test
+
+// --- Stub ./direct-pg: always returns one enabled row, records call count. ---
+let dbCalls = 0;
+const directPgPath = require.resolve('../lib/direct-pg');
+require.cache[directPgPath] = {
+  id: directPgPath,
+  filename: directPgPath,
+  loaded: true,
+  exports: {
+    pgQuery: async () => {
+      dbCalls += 1;
+      return [{ enabled: true }];
+    },
+  },
+  children: [],
+  paths: [],
+};
+
+// --- Stub @upstash/redis: get/set always reject, mirroring "fetch failed". ---
+let redisGetCalls = 0;
+let redisSetCalls = 0;
+let shouldFail = true;
+class FakeRedis {
+  async get() {
+    redisGetCalls += 1;
+    if (shouldFail) throw new Error('fetch failed');
+    return null;
+  }
+  async set() {
+    redisSetCalls += 1;
+    if (shouldFail) throw new Error('fetch failed');
+  }
+  async del() {}
+}
+const upstashPath = require.resolve('@upstash/redis');
+require.cache[upstashPath] = {
+  id: upstashPath,
+  filename: upstashPath,
+  loaded: true,
+  exports: { Redis: FakeRedis },
+  children: [],
+  paths: [],
+};
+
+const { isAgentEnabled } = require('../lib/agent-controls');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  // Calls 1–3: breaker is closed, every call attempts the (failing) redis GET.
+  // Call 1 also misses memCache, so it reads the DB and attempts a (failing)
+  // redis SET too — that is the 3rd consecutive failure, so the breaker opens
+  // on THIS call, not the next one.
+  assert.equal(await isAgentEnabled('trinity-test-breaker'), true);
+  assert.equal(redisGetCalls, 1);
+  assert.equal(redisSetCalls, 1);
+  assert.equal(dbCalls, 1, 'first call is a memCache miss, so it must hit the DB');
+
+  // Call 2: GET failure #3 (threshold) — breaker opens on this call.
+  assert.equal(await isAgentEnabled('trinity-test-breaker'), true, 'memCache still serves the right answer');
+  assert.equal(redisGetCalls, 2);
+  assert.equal(dbCalls, 1, 'memCache hit — no second DB read');
+
+  // Call 3: breaker should now be OPEN — getRedis() short-circuits before the
+  // GET is ever attempted.
+  assert.equal(await isAgentEnabled('trinity-test-breaker'), true);
+  assert.equal(redisGetCalls, 2, 'breaker open: no further redis calls while cooling down');
+
+  // Wait out the (deliberately short) cooldown, then let the next attempt
+  // succeed — the breaker should close again and resume normal calls.
+  await sleep(200);
+  shouldFail = false;
+  assert.equal(await isAgentEnabled('trinity-test-breaker'), true);
+  assert.equal(redisGetCalls, 3, 'breaker closed after cooldown: GET attempted again');
+
+  console.log('agentControlsRedisBreaker.test.js: OK');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What's broken

Every deployed agent service (trinity-gcm, trinity-sophia, trinity-hdm, trinity-torch, trinity-veritas) is logging `[agent-controls] redis cache read failed: fetch failed` / `redis cache write failed: fetch failed` on an unbroken loop, for days — observed directly in Railway deploy logs on trinity-hdm (since at least 2026-08-20), trinity-sophia (since 2026-08-24), and trinity-gcm (today, still ongoing).

`UPSTASH_REDIS_REST_URL` is set — `getRedis()` returns `null` immediately when it's unset, which would mean no warning ever prints — so the env var exists but the endpoint it names is unreachable.

## Why it wasn't breaking anything, but needed fixing anyway

`isAgentEnabled()` already degrades gracefully: Upstash → in-process `memCache` → direct Postgres read, in that order, so the enable/disable gate has been answering correctly the whole time. This was never a correctness bug. But every single call to `isAgentEnabled()` was still paying a live network round-trip to a known-dead host and logging a warning for it — forever, on every one of the five agent services, continuously, drowning out real signal in the logs.

## The fix

Same circuit-breaker shape `lib/direct-pg.js` already uses for its own Postgres pool (documented in its own header: 5 consecutive failures → 5min cooldown). Applied here to the Upstash client: after 3 consecutive failures, stop calling Upstash for a cooldown window (default 5 minutes, `AGENT_CONTROL_REDIS_COOLDOWN_MS`) and log the open/close transition once instead of on every call. A live Upstash endpoint never sees a failure, so the breaker never opens for it — this changes nothing for a healthy deployment.

**Not fixed here:** the actual dead Upstash instance/credentials. That needs whoever holds the Upstash dashboard access to check `UPSTASH_REDIS_REST_URL` against a live database. This stops the chronic noise and wasted round-trips in the meantime.

## Tests

`tests/agentControlsRedisBreaker.test.js` (new) pins:
- 3 consecutive failures open the breaker
- no further Upstash calls happen while the breaker is open
- the DB + memCache fallback keeps answering correctly throughout
- a recovered endpoint is used again once the cooldown elapses

Wired into `ci.yml` in the same commit — `agent-controls.test.js` was already in exactly this situation once (existed, passed, was never actually run in CI until a previous fix added it), so the new test goes in with the code it covers rather than repeating that gap.

All existing tests in the CI list still pass locally:
```
getNextTask, supabaseServiceKeyResolve, claimCap, claimCallSite, provenance,
pulseCheckExecutor, heartbeatDbWritesGate, emergency-halt, emergency-halt-coverage,
agent-controls, agentControlsRedisBreaker (new), survivorLiveness
```

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01URro6Bg5J9zkiFL4sC1vXw)_