### PR TITLE
docs: a coordination protocol two agents can actually use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,86 @@ Files in packages/contracts/ are protected. Do not modify:
 - packages/contracts/test/*
 - packages/contracts/abis/*
 
+## Two agents share this database and these repos — claim before you touch
+
+**CC** runs in a remote cloud container. **GA** runs on Sean's laptop. Both have
+GitHub and Supabase access, and `ListAgents` returns nothing across that
+boundary, so **the two cannot message each other.** Supabase is the only
+substrate both reach, which is why coordination lives there.
+
+### 1. Never share a branch name
+
+The cheapest half of this needs no machinery. Namespace your branches by who you
+are, and the largest collision class disappears:
+
+| agent | branch prefix |
+|---|---|
+| CC (remote) | `claude/…` |
+| GA (local)  | `ga/…` |
+| XC          | `xc/…` |
+
+Two agents force-pushing one branch name is not a conflict you resolve — it is
+work that silently disappears.
+
+### 2. Claim a shared mutable resource before changing it
+
+```sql
+-- Before you start:
+select * from v_active_claims;
+
+select claim_resource(
+  'supabase_table',            -- git_branch | supabase_table | supabase_migration
+                               -- railway_service | env_var | other
+  'repid_agents',              -- 'owner/repo#branch' for a branch
+  'GA',                        -- who you are
+  'adding a column for X',     -- why, one line
+  60                           -- TTL minutes; it EXPIRES, always
+);
+
+-- When done:
+select release_resource('supabase_table','repid_agents','GA');
+```
+
+`claim_resource` **raises** rather than returning null when someone else holds
+it — a caller that ignored a null return would have proceeded without the lock,
+which is the exact failure this exists to prevent. The message names the holder
+and the expiry.
+
+**The exclusion is the unique index `uniq_active_claim`, not the function.** A
+second live claim on one resource is impossible at the storage layer, so
+skipping the helper still cannot double-claim. Same reasoning as
+`social_content_queue_verified_before_publish`: app code is where a gate gets
+forgotten.
+
+**Every claim expires.** A lock with no TTL becomes a permanent outage the first
+time a session dies holding it, and these sessions are ephemeral. An expired
+claim is cleared automatically by the next `claim_resource` call — you do not
+need to reap it.
+
+### 3. What actually collides
+
+Measured on 2026-08-29, three times in one session, all the same shape: **work
+landed on `main` while a PR against it was open, and the branch then conflicted
+with the squash of its own commit.** After any merge, reset your branch onto the
+new `main` rather than stacking on it:
+
+```bash
+git fetch origin main && git checkout -B <your-branch> origin/main
+```
+
+A squash-merged commit is in `main` by content but is **not an ancestor**, so
+`git merge-base --is-ancestor` says "not merged" about work that shipped. Check
+`git diff HEAD origin/main` — empty means your work is in, whatever the ancestry
+says.
+
+### 4. Migrations are the sharp edge
+
+Both agents can call `apply_migration` against the one production project
+(`qnnpjhlxljtqyigedwkb`). There is no staging copy. Claim
+`supabase_migration` + the table name before DDL, and say in `purpose` what you
+are changing — a concurrent `ALTER` on the same table is not recoverable by
+re-running.
+
 ## Tooling Notes
 
 - GitNexus auto-generation skipped due to broken tree-sitter-dart SSH dependency in the project. Manual rules block in use until GitNexus dependency is fixed upstream or Codebase-Memory alternative is evaluated.


### PR DESCRIPTION
## The problem, measured

GA runs on Sean's laptop with GitHub and Supabase access. CC runs in a remote cloud container. **`ListAgents` returns nothing across that boundary** — the two cannot message each other. Supabase is the only substrate both reach, which is why the mechanism lives there.

This is not hypothetical. **Three collisions on 2026-08-29**, all the same shape: work landed on `main` while a PR against it was open, and the branch then conflicted with the squash of its own commit. [shared#45](https://github.com/DealAppSeo/trinity-symphony-shared/pull/45) hit it mid-merge and had to be rebased before it would go in.

## Three parts, cheapest first

### 1. Branch namespacing — no machinery at all

`claude/…` for CC, `ga/…` for GA, `xc/…` for XC. Two agents force-pushing one branch name is not a conflict anyone resolves — **it is work that silently disappears.** This eliminates the largest collision class for the price of a convention.

### 2. `agent_resource_claims`

Migration `agent_resource_claims_mutual_exclusion`, with `claim_resource()` / `release_resource()` / `v_active_claims`.

**The exclusion is the unique partial index, not the function.** Same reasoning as `social_content_queue_verified_before_publish`: app code is where a gate gets forgotten, so a caller that skips the helper still cannot double-claim.

**`claim_resource` raises rather than returning null** when the resource is held. A null return gets ignored, and an ignored null means the caller proceeded *without* the lock — the exact failure the lock exists to prevent. The message names the holder and the expiry.

**Every claim expires.** A lock without a TTL becomes a permanent outage the first time a session dies holding it, and these sessions are ephemeral. Expired claims are cleared by the next `claim_resource` call; nobody has to reap them.

Both paths were **proven before this was written**:

```
CC claims a branch                          → claim id 1
GA claims the same branch                   → ERROR: CLAIMED: … held by CC until 20:09:52
CC's claim backdated as if the session died → GA claims successfully (id 2)
```

The middle test also caught a bug in *my own test*: backdating only `expires_at` violated the `expires_at > claimed_at` CHECK, which is the constraint doing its job. Fixed the test, not the constraint.

### 3. The squash-merge trap, stated explicitly

It is what actually keeps biting. A squash-merged commit is in `main` **by content** but is **not an ancestor**, so `git merge-base --is-ancestor` reports "not merged" about work that shipped. `git diff HEAD origin/main` is the honest check — empty means your work is in, whatever the ancestry says.

## Migrations are the sharp edge

Both agents hold `apply_migration` against **one production project with no staging copy**. A concurrent `ALTER` on the same table is not recoverable by re-running. Claim `supabase_migration` + the table name before any DDL.

## Announced, not just written

Posted to `team_coordination_log` (id 46), which had been **dead since 2026-06-20**. A protocol the other party never reads is wired at one end — worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtRGdqH6BZcXDDFDE4EFHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtRGdqH6BZcXDDFDE4EFHP)_